### PR TITLE
Change license to Apache 2.0 with Commons Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,38 @@
-MIT License
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Copyright (c) 2026 Matthew Newhook
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright 2025, Peaberry Software, Inc. d/b/a Customer.io
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License
+and the Commons Clause Restriction. You may obtain a copy of the
+License at
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Commons Clause Restriction
+The Software is provided to you by the Licensor under the License,
+as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights
+under the License will not include, and the License does not grant to you,
+the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of
+the rights granted to you under the License to provide to third parties,
+for a fee or other consideration (including without limitation fees for
+hosting or consulting/ support services related to the Software), a product
+or service whose value derives, entirely or substantially, from the
+functionality of the Software. Any license notice or attribution required
+by the License must also include this Commons Clause Restriction notice.


### PR DESCRIPTION
## Summary

This PR changes the project license from MIT to Apache 2.0 with Commons Clause Restriction.

### Changes

- Replaced MIT License with Apache License 2.0
- Added Commons Clause Restriction to prevent commercial resale of the software
- Updated copyright to Peaberry Software, Inc. d/b/a Customer.io

### What is the Commons Clause?

The Commons Clause is a license condition that restricts the right to "Sell" the software. Specifically:

- You **can** use, modify, and distribute the software
- You **cannot** sell the software or provide paid services that derive substantial value from the software's functionality
- This includes hosting services, consulting, and support services sold to third parties

### Breaking Changes

**License change**: Users who previously relied on the MIT license's permissiveness for commercial purposes may need to review their usage. The new license:
- Still allows free use for internal purposes
- Still allows contributions and modifications
- Restricts commercial resale and SaaS-style offerings based on the software

### Issues Resolved

- Closes ac-p1p: Change license

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)