### PR TITLE
Update README license section to Apache 2.0 with Commons Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ bd ready  # View available beads
 
 ## License
 
-MIT
+Apache 2.0 with Commons Clause. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

Updates the README.md license section to accurately reflect the project's Apache 2.0 with Commons Clause license.

## Changes

- Updated the License section in README.md from "MIT" to "Apache 2.0 with Commons Clause" with a link to the LICENSE file

## Issues Resolved

- **ac-p1p.1**: Update README license section to Apache 2.0 with Commons Clause
  - The README previously stated "MIT" but the LICENSE file was changed to Apache 2.0 with Commons Clause

## Testing

- Verified README.md renders correctly with the license link
- No code changes, documentation only

---

🤖 Generated with [Claude Code](https://claude.ai/code)