### PR TITLE
Ensure root issue visible in issues tab when work panel present

### DIFF
--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -1779,10 +1779,12 @@ func (m *planModel) updateWorkSelectionFilter() tea.Cmd {
 	// Save old filter values to detect actual changes
 	oldTask := m.filters.task
 	oldChildren := m.filters.children
+	oldRootIssue := m.filters.rootIssue
 
 	// Clear existing entity filters
 	m.filters.task = ""
 	m.filters.children = ""
+	m.filters.rootIssue = ""
 
 	if m.focusedWorkID == "" {
 		return nil
@@ -1791,6 +1793,11 @@ func (m *planModel) updateWorkSelectionFilter() tea.Cmd {
 	focusedWork := m.workDetails.GetFocusedWork()
 	if focusedWork == nil {
 		return nil
+	}
+
+	// Always set root issue when work panel is present so it's always visible
+	if focusedWork.Work.RootIssueID != "" {
+		m.filters.rootIssue = focusedWork.Work.RootIssueID
 	}
 
 	if m.workDetails.IsTaskSelected() {
@@ -1807,7 +1814,7 @@ func (m *planModel) updateWorkSelectionFilter() tea.Cmd {
 	}
 
 	// Only reset cursor when filter actually changes (not on every refresh)
-	if m.filters.task != oldTask || m.filters.children != oldChildren {
+	if m.filters.task != oldTask || m.filters.children != oldChildren || m.filters.rootIssue != oldRootIssue {
 		m.beadsCursor = 0
 	}
 

--- a/internal/tui/tui_plan_data.go
+++ b/internal/tui/tui_plan_data.go
@@ -107,6 +107,7 @@ func (m *planModel) loadBeadsWithFilters(filters beadFilters) ([]beadItem, error
 
 // loadBeadsForTask loads beads assigned to a specific task.
 // This fetches all beads for the task regardless of status filter.
+// If filters.rootIssue is set, the root issue is prepended to the results.
 func (m *planModel) loadBeadsForTask(filters beadFilters) ([]beadItem, error) {
 	// Get bead IDs assigned to this task from the database
 	beadIDs, err := m.proj.DB.GetTaskBeads(m.ctx, filters.task)
@@ -114,12 +115,24 @@ func (m *planModel) loadBeadsForTask(filters beadFilters) ([]beadItem, error) {
 		return nil, fmt.Errorf("failed to get task beads: %w", err)
 	}
 
-	if len(beadIDs) == 0 {
-		return nil, nil
+	// Track which IDs we have to avoid duplicates
+	beadIDSet := make(map[string]bool)
+	for _, id := range beadIDs {
+		beadIDSet[id] = true
+	}
+
+	// Start with root issue if specified and not already in the task
+	var items []beadItem
+	if filters.rootIssue != "" && !beadIDSet[filters.rootIssue] {
+		rootBead, err := m.proj.Beads.GetBead(m.ctx, filters.rootIssue)
+		if err == nil && rootBead != nil {
+			items = append(items, beadItem{
+				BeadWithDeps: rootBead,
+			})
+		}
 	}
 
 	// Fetch the beads from the beads client (uses cache)
-	var items []beadItem
 	for _, beadID := range beadIDs {
 		bead, err := m.proj.Beads.GetBead(m.ctx, beadID)
 		if err != nil || bead == nil {
@@ -128,6 +141,10 @@ func (m *planModel) loadBeadsForTask(filters beadFilters) ([]beadItem, error) {
 		items = append(items, beadItem{
 			BeadWithDeps: bead,
 		})
+	}
+
+	if len(items) == 0 {
+		return nil, nil
 	}
 
 	// Apply search text filter if set

--- a/internal/tui/tui_shared.go
+++ b/internal/tui/tui_shared.go
@@ -169,6 +169,9 @@ type beadFilters struct {
 	// Entity-based filters (override status filter when set)
 	task     string // task ID - show beads assigned to this task
 	children string // bead ID - show children (dependents) of this bead
+
+	// Context filters (always applied when work panel is present)
+	rootIssue string // root issue ID - always include in results when set
 }
 
 // beadTypes is the list of valid bead types


### PR DESCRIPTION
## Summary

When the work panel is present in the TUI, the root issue now always remains visible in the issues tab, regardless of which task or bead is selected.

**Problem:** Previously, when a task or unassigned bead was selected in the work panel, the root issue would disappear from the issues tab since the filter only showed beads assigned to the selected task.

**Solution:** Added a `rootIssue` context filter that is set whenever a work panel is focused. This ensures the root issue is always prepended to the issues list when it's not already included in the filtered results.

## Changes

- **`internal/tui/tui_shared.go`**: Added `rootIssue` field to `beadFilters` struct for context-based filtering
- **`internal/tui/tui_plan.go`**: Modified `updateWorkSelectionFilter()` to:
  - Set `rootIssue` filter when work panel is present
  - Track filter changes to properly reset cursor position
- **`internal/tui/tui_plan_data.go`**: Modified `loadBeadsForTask()` to:
  - Prepend root issue to results when set and not already included
  - Handle deduplication to avoid showing root issue twice

## Issues Resolved

- `ac-r9k`: When the work panel is present the issues tab should always show the root issue

## Testing

- Select a work in the TUI with the work panel visible
- Select different tasks → root issue should remain visible in issues tab
- Select root issue → root issue and dependents shown (unchanged behavior)
- Select unassigned beads → root issue plus selected bead shown

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)