### PR TITLE
Fix log_analysis tasks getting stuck when Claude exits without completing

### DIFF
--- a/cmd/orchestrate.go
+++ b/cmd/orchestrate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sargehq/sarge/internal/claude"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/feedback"
+	"github.com/sargehq/sarge/internal/logging"
 	"github.com/sargehq/sarge/internal/orchestration"
 	"github.com/sargehq/sarge/internal/procmon"
 	"github.com/sargehq/sarge/internal/project"
@@ -282,6 +283,23 @@ func executeTask(proj *project.Project, t *db.Task, work *db.Work, runner claude
 			return fmt.Errorf("task %s timed out after %v", t.ID, timeout)
 		}
 		return err
+	}
+
+	// Defensive: auto-complete log_analysis tasks if Claude exited without calling sarge complete.
+	// Log analysis tasks are observational (they create beads but don't modify code), so it's
+	// safe to auto-complete them. This prevents the orchestrator from spinning forever.
+	if t.TaskType == "log_analysis" {
+		updatedTask, err := proj.DB.GetTask(ctx, t.ID)
+		if err != nil {
+			fmt.Printf("Warning: failed to re-read task %s status: %v\n", t.ID, err)
+		} else if updatedTask != nil && updatedTask.Status == db.StatusProcessing {
+			logging.Warn("auto-completing log_analysis task that Claude did not mark complete",
+				"task_id", t.ID)
+			fmt.Printf("Warning: Claude exited without completing log_analysis task %s, auto-completing\n", t.ID)
+			if err := proj.DB.CompleteTask(ctx, t.ID, ""); err != nil {
+				fmt.Printf("Warning: failed to auto-complete task %s: %v\n", t.ID, err)
+			}
+		}
 	}
 
 	// Post-execution handling based on task type

--- a/internal/claude/runner_test.go
+++ b/internal/claude/runner_test.go
@@ -72,7 +72,7 @@ func TestBuildLogAnalysisPrompt(t *testing.T) {
 			wantContains: []string{
 				"Work w-test",
 				"Job: Integration",
-				"The CI log output is in:",
+				"REQUIRED: Mark Task Complete",
 			},
 		},
 		{
@@ -88,7 +88,7 @@ func TestBuildLogAnalysisPrompt(t *testing.T) {
 			},
 			wantContains: []string{
 				"/tmp/ci-log-12345.txt",
-				"Read this file to analyze the failures",
+				"sarge complete w-multi.3",
 			},
 		},
 	}

--- a/internal/claude/templates/log_analysis.tmpl
+++ b/internal/claude/templates/log_analysis.tmpl
@@ -1,3 +1,5 @@
+**MANDATORY**: When you are finished, your FINAL action MUST be running: `sarge complete {{.TaskID}}`
+
 You are analyzing CI logs for Work {{.WorkID}}.
 
 Branch: {{.BranchName}}
@@ -12,10 +14,13 @@ The following issues already exist. Before creating a new bead, check if any fai
   {{.Description}}{{end}}
 {{end}}
 {{end}}
-Instructions:
-1. Analyze the CI log output below to identify all failures, errors, and issues.
+## Instructions
 
-2. For each distinct failure found:
+1. Read the CI log file: {{.LogFilePath}}
+
+2. Analyze the log to identify all failures, errors, and issues.
+
+3. For each distinct failure found:
    a. **First check** if it matches an existing issue above (same test name, same error type, same root cause)
    b. If it matches an existing issue: **skip it** (already tracked, no action needed)
    c. If it's a new failure: create a bead{{if .RootIssueID}} under the root issue{{end}}:
@@ -25,18 +30,18 @@ Instructions:
      --description "<detailed description>"
    ```
 
-3. Priority Guidelines:
+4. Priority Guidelines:
    - P0 (--priority 0): Security vulnerabilities, critical runtime errors
    - P1 (--priority 1): Build failures, compilation errors
    - P2 (--priority 2): Test failures, lint errors
    - P3 (--priority 3): Warnings, minor style issues
 
-4. Description should include:
+5. Description should include:
    - File path and line number (if available)
    - The error message
    - Relevant context from the log
 
-5. Examples:
+6. Examples:
    ```
    # Test failure
    bd create "Fix TestUserAuthentication failure"{{if .RootIssueID}} --parent {{.RootIssueID}}{{end}} --type bug \
@@ -54,9 +59,11 @@ Instructions:
      --description "Lint error at internal/utils/helper.go:23 - exported function should have comment"
    ```
 
-6. **Always** mark the task complete when done: `sarge complete {{.TaskID}}`
-   Run this whether you created beads, matched existing issues, or found no failures at all.
+## REQUIRED: Mark Task Complete
 
-The CI log output is in: {{.LogFilePath}}
-
-Read this file to analyze the failures.
+YOUR FINAL ACTION MUST be running this command:
+```
+sarge complete {{.TaskID}}
+```
+Run this whether you created beads, matched existing issues, or found no failures at all.
+Do NOT exit without running this command.


### PR DESCRIPTION
## Summary

Fixes an issue where `log_analysis` tasks would get stuck in `processing` state indefinitely, causing the orchestrator to spin forever waiting for completion.

**Root cause:** The `sarge complete` instruction in the log analysis prompt template was buried as item #6 in a numbered list. Smaller models (Haiku) treated this as informational guidance rather than a command to execute — outputting "Task Complete" as text and exiting without actually running the command. The orchestrator would then loop endlessly at the "Waiting for N processing task(s)..." state.

## Changes

### 1. Strengthen completion instruction in prompt template (`internal/claude/templates/log_analysis.tmpl`)
- Moved `sarge complete` instruction to both the **top** (as a `MANDATORY` banner) and **bottom** (as a `## REQUIRED` section) of the prompt
- Used stronger imperative language: "YOUR FINAL ACTION MUST be running this command"
- Separated from the numbered instruction list into its own dedicated section
- Moved "Read this file" directive into step 1 of instructions for better flow

### 2. Defensive auto-complete for log_analysis tasks (`cmd/orchestrate.go`)
- After `runner.Run()` returns for a `log_analysis` task, re-reads task status from the database
- If the task is still in `processing` state, auto-completes it with a warning log
- Log analysis tasks are observational (they create beads but don't modify code), so auto-completing is safe
- This prevents the orchestrator from getting stuck even if the model still fails to call `sarge complete`

### 3. Updated tests (`internal/claude/runner_test.go`)
- Updated `TestBuildLogAnalysisPrompt` assertions to match the restructured template

## Issues Resolved

- `ac-d18` — PR log review gets stuck
- `ac-d18.1` — Strengthen sarge complete instruction in log_analysis.tmpl prompt
- `ac-d18.2` — Auto-complete log_analysis tasks when Claude exits without calling sarge complete

## Testing

- Unit tests pass (`go test ./...`)
- Code review completed (task w-3gl.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)