### PR TITLE
Update docs: sarge launches TUI directly without subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ The command:
 
 ### TUI Integration
 
-The TUI (`sarge tui`) provides:
+The TUI (`sarge`) provides:
 - F5 key binding for manual feedback polling
 - Visual feedback indicator showing polling status
 - Automatic refresh when new beads are created from feedback
@@ -644,7 +644,7 @@ Monitors work/task progress with simple text output:
 - With work ID: monitors that work's tasks
 - With task ID: monitors that specific task
 - Use `--interval` to set polling interval (default: 2s)
-- For interactive TUI with management features, use `sarge tui` instead
+- For interactive TUI with management features, use `sarge` instead
 
 ### `sarge sync`
 Pulls from upstream in all repositories:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Sarge provides two ways to interact with your project:
 The interactive terminal UI provides a lazygit-style interface:
 
 ```bash
-sarge tui
+sarge
 ```
 
 Features:
@@ -187,7 +187,7 @@ Sarge uses [Beads](https://github.com/steveyegge/beads), a distributed git-backe
 - **Collision-free IDs** - Hash-based IDs eliminate merge conflicts in multi-branch scenarios
 - **Semantic compaction** - Completed tasks are summarized to conserve AI context windows
 
-**You rarely need to use beads directly.** Claude Code (with the beads skill) and the TUI handle all issue management. The `bd` CLI is available if you need it, but most users interact with beads through `sarge tui` or let Claude manage issues automatically.
+**You rarely need to use beads directly.** Claude Code (with the beads skill) and the TUI handle all issue management. The `bd` CLI is available if you need it, but most users interact with beads through `sarge` or let Claude manage issues automatically.
 
 ### Three-Tier Hierarchy
 

--- a/cmd/poll.go
+++ b/cmd/poll.go
@@ -36,7 +36,7 @@ Output shows:
 - Status indicators (○ pending, ● processing, ✓ completed, ✗ failed)
 
 For interactive management (create, destroy, plan, run works),
-use 'sarge tui' instead.`,
+use 'sarge' instead.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runPoll,
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -250,12 +250,12 @@ Task is auto-detected from CO_TASK_ID env var or current processing review task.
 
 ## Monitoring Commands
 
-### `sarge tui`
+### `sarge`
 
-Interactive TUI for managing works and beads (lazygit-style).
+When run without a subcommand, sarge launches the interactive TUI for managing works and beads (lazygit-style).
 
 ```bash
-sarge tui
+sarge
 ```
 
 Features:


### PR DESCRIPTION
## Summary
- Running `sarge` (without arguments) now launches the TUI directly
- Removed references to `sarge tui` subcommand from documentation
- Updated help text in `cmd/poll.go` to reference `sarge` instead of `sarge tui`

## Files Changed
- `README.md` - Updated TUI launch instructions
- `CLAUDE.md` - Updated TUI references in documentation
- `docs/cli-reference.md` - Updated monitoring commands section
- `cmd/poll.go` - Updated help text

## Test plan
- [x] `go build` succeeds
- [x] `go test ./cmd/...` passes
- [ ] Running `sarge` without arguments launches TUI