### PR TITLE
Strengthen log analysis prompt to prevent interactive behavior

### DIFF
--- a/internal/claude/templates/log_analysis.tmpl
+++ b/internal/claude/templates/log_analysis.tmpl
@@ -1,4 +1,6 @@
-**MANDATORY**: When you are finished, your FINAL action MUST be running: `sarge complete {{.TaskID}}`
+**THIS IS A FULLY AUTOMATED TASK. DO NOT ask questions, request clarification, or wait for user input. There is no human to respond. If you cannot determine failures from the log, complete the task with no beads created.**
+
+**MANDATORY**: Your FINAL action MUST be running: `sarge complete {{.TaskID}}`
 
 You are analyzing CI logs for Work {{.WorkID}}.
 
@@ -19,6 +21,8 @@ The following issues already exist. Before creating a new bead, check if any fai
 1. Read the CI log file: {{.LogFilePath}}
 
 2. Analyze the log to identify all failures, errors, and issues.
+   - If the log appears truncated, incomplete, or contains no identifiable failures, **do not ask questions**. Simply complete the task with no beads created.
+   - If errors are ambiguous, use your best judgment to create beads for the most likely failures.
 
 3. For each distinct failure found:
    a. **First check** if it matches an existing issue above (same test name, same error type, same root cause)
@@ -65,5 +69,10 @@ YOUR FINAL ACTION MUST be running this command:
 ```
 sarge complete {{.TaskID}}
 ```
-Run this whether you created beads, matched existing issues, or found no failures at all.
-Do NOT exit without running this command.
+Run this in ALL cases:
+- You created beads for new failures
+- All failures matched existing issues
+- No failures were found in the log
+- The log was truncated or unreadable
+
+Do NOT exit without running this command. Do NOT ask the user any questions.


### PR DESCRIPTION
## Summary

- Strengthened the `log_analysis.tmpl` prompt to explicitly prevent Claude from entering interactive Q&A mode during automated CI log analysis tasks
- Added a clear automated-task directive at the top of the prompt
- Added instructions for handling truncated/incomplete logs without asking questions
- Expanded the completion instructions to cover all edge cases

## Problem

When Claude couldn't identify failures in a CI log (e.g., truncated logs, missing test output), it would enter interactive mode — asking the user questions and waiting for input. Since log analysis runs as a fully automated task in a zellij tab with no human present, this caused the task to block indefinitely.

## Changes

**`internal/claude/templates/log_analysis.tmpl`**:
- Added prominent automated-task directive at the top: "DO NOT ask questions, request clarification, or wait for user input"
- Added explicit handling for truncated/incomplete logs (complete the task with no beads instead of asking questions)
- Added guidance to use best judgment for ambiguous errors
- Expanded the final completion section to enumerate all scenarios (beads created, matched existing, no failures, truncated log)
- Reinforced no-questions policy at the end of the prompt

## Issues Resolved

- `ac-cjw`: More log analysis failures (root issue)
- `ac-cjw.1`: Strengthen log analysis prompt to prevent interactive behavior
- `ac-cjw.2`: Use --max-turns flag for log analysis Claude invocations (deferred — prompt fix deemed sufficient)

## Testing

- The prompt changes are template-only with no logic changes
- Verified template still renders correctly with all placeholder variables
- Real-world validation will occur on the next CI log analysis task

🤖 Generated with [Claude Code](https://claude.com/claude-code)