### PR TITLE
Fix documentation drift and improve onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Sarge is designed to manage an army of Claude agents, turning your issue tracker
 1. **Create or import issues** - Define work in your issue tracker (beads), or import from Linear
 2. **Plan the implementation** - Use Claude Code interactively to break down complex issues into actionable tasks
 3. **Execute with a Work** - Create a work unit that represents a git worktree and feature branch
-4. **Automatic execution** - CO orchestrates Claude to solve all issues, commit changes, and push continuously
+4. **Automatic execution** - Sarge orchestrates Claude to solve all issues, commit changes, and push continuously
 5. **Code review** - Claude automatically reviews its own work, creating fix issues for any problems found
 6. **PR creation** - Once implementation and review pass, Claude creates a comprehensive PR
 7. **Handle feedback** - CI failures and review comments automatically become new issues, which can be planned or added to the existing work
@@ -116,7 +116,23 @@ sarge proj create ~/myproject ~/path/to/repo
 cd ~/myproject
 ```
 
-### 2. Choose Your Interface
+This clones the repo (or symlinks a local one), installs tools via mise, and initializes the beads issue tracker.
+
+### 2. Create Issues
+
+Create issues in the beads tracker for sarge to work on:
+
+```bash
+cd main
+bd create --title "Add user authentication" --type feature
+bd create --title "Fix login page crash" --type bug --priority 1
+bd ready   # See what's available
+cd ..
+```
+
+Or import from Linear: `sarge linear import ENG-123`
+
+### 3. Choose Your Interface
 
 Sarge provides two ways to interact with your project:
 
@@ -130,7 +146,7 @@ sarge
 
 Features:
 - Three-panel drill-down: Beads → Works → Tasks
-- Create/destroy works, run tasks
+- Create/destroy works, run tasks, monitor progress
 - Bead filtering, search, multi-select
 - Press `?` for keyboard shortcuts
 
@@ -139,7 +155,7 @@ Features:
 Use individual commands for scripting or when you prefer the command line:
 
 ```bash
-# Create a work unit from a bead
+# Create a work unit from a bead (creates worktree + feature branch)
 sarge work create bead-1
 
 # Navigate to the work directory
@@ -148,8 +164,23 @@ cd w-abc
 # Execute tasks
 sarge run
 
-# Or use full automation
+# Or skip the manual steps - full automation in one command
 sarge work create bead-1 --auto
+```
+
+### 4. Monitor and Merge
+
+```bash
+# Check on progress
+sarge poll
+
+# Once work is idle (all tasks finished), review the PR
+sarge work pr          # Creates PR via Claude
+sarge run              # Executes the PR task
+
+# After PR approval
+sarge work complete    # Mark work as done
+sarge work destroy w-abc
 ```
 
 ## Project Commands

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,9 +25,12 @@ Transitive dependencies are also included.
 
 The branch name is generated from bead titles and you're prompted for confirmation.
 
-| Flag | Description |
-|------|-------------|
-| `--auto` | Full automated workflow (implement, review/fix loop, PR) |
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--auto` | | Full automated workflow (implement, review/fix loop, PR) |
+| `--branch` | | Branch name to use (skips the confirmation prompt) |
+| `--from-branch` | | Use an existing git branch instead of creating a new one |
+| `--yes` | `-y` | Skip confirmation prompts |
 
 Base branch is configured in `config.toml` under `[repo] base_branch` (default: main).
 
@@ -116,6 +119,28 @@ sarge work complete w-abc  # Explicit ID
 - Transitions work to `completed` (terminal state)
 - Use when PR is merged or work is truly finished
 
+### `sarge work console [<id>]`
+
+Opens a zellij tab with a shell in the work's worktree.
+
+```bash
+sarge work console        # Current directory
+sarge work console w-abc  # Explicit ID
+```
+
+Useful for running tests, exploring the codebase, or debugging while the orchestrator runs in a separate tab.
+
+### `sarge work claude [<id>]`
+
+Opens a zellij tab with an interactive Claude Code session in the work's worktree.
+
+```bash
+sarge work claude        # Current directory
+sarge work claude w-abc  # Explicit ID
+```
+
+Useful for manual exploration, debugging, or ad-hoc changes while the orchestrator runs in a separate tab.
+
 ### `sarge work pr [<id>]`
 
 Creates a PR task for Claude to generate a pull request.
@@ -125,7 +150,7 @@ sarge work pr          # Current directory
 sarge work pr w-abc    # Explicit ID
 ```
 
-Work must be completed before creating PR. After creating the PR task, run `sarge run` to execute it.
+Work must be idle (all tasks finished) before creating a PR. After creating the PR task, run `sarge run` to execute it.
 
 ### `sarge work review [<id>]`
 
@@ -143,6 +168,25 @@ sarge work review --auto       # Review-fix loop
 
 Claude examines the work's branch for quality and security issues and creates beads for issues found.
 
+### `sarge work import-pr <pr-url>`
+
+Creates a work unit from an existing GitHub pull request.
+
+```bash
+sarge work import-pr https://github.com/owner/repo/pull/123
+sarge work import-pr https://github.com/owner/repo/pull/123 --branch custom-branch-name
+```
+
+| Flag | Description |
+|------|-------------|
+| `--branch` | Override the local branch name (default: use PR's branch name) |
+
+This command:
+- Fetches PR metadata (title, author, branch, state)
+- Creates a bead from the PR metadata
+- Sets up a work unit with the PR's feature branch
+- Schedules worktree creation via the control plane
+
 ### `sarge work feedback [<id>]`
 
 Processes PR feedback and creates beads from actionable items.
@@ -151,15 +195,11 @@ Processes PR feedback and creates beads from actionable items.
 sarge work feedback                    # Current directory
 sarge work feedback w-abc              # Explicit ID
 sarge work feedback --dry-run          # Preview only
-sarge work feedback --auto-add         # Add beads to work
-sarge work feedback --min-priority 2   # Filter by priority
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | Preview what beads would be created |
-| `--auto-add` | Automatically add beads to work |
-| `--min-priority N` | Set minimum priority (0-4) |
 
 The feedback system processes:
 - **CI/Build Failures**: Failed status checks and workflow runs
@@ -188,6 +228,8 @@ sarge run --dry-run            # Preview execution plan
 | `--dry-run` | | Show execution plan without running |
 | `--plan` | | Use LLM complexity estimation to auto-group beads |
 | `--auto` | | Full automated workflow (implement, review/fix loop, PR) |
+| `--auto-close` | | Automatically close zellij tabs after task completion |
+| `--force-estimate` | | Force re-estimation of complexity (use with `--plan`) |
 | `--project` | | Specify project directory (default: auto-detect from cwd) |
 | `--work` | | Specify work ID (default: auto-detect from current directory) |
 
@@ -236,17 +278,6 @@ sarge task reset w-abc.1
 ```
 
 Changes task status from processing/failed back to pending. Resets all bead statuses for the task.
-
-### `sarge task set-review-epic <epic-id>`
-
-Associates a review epic with a review task.
-
-```bash
-sarge task set-review-epic epic-1
-sarge task set-review-epic epic-1 --task w-abc.2
-```
-
-Task is auto-detected from CO_TASK_ID env var or current processing review task.
 
 ## Monitoring Commands
 
@@ -305,6 +336,16 @@ sarge list --status completed
 |------|-------------|
 | `--status` | Filter: pending, processing, completed, failed |
 
+### `sarge plan <bead-id>`
+
+Launches an interactive Claude Code session for planning work on a specific issue.
+
+```bash
+sarge plan bead-1
+```
+
+Typically invoked by the TUI's Plan mode, which creates a zellij tab for each issue. Claude can investigate the issue, break it down into subtasks, plan implementation strategies, and create related issues.
+
 ### `sarge sync`
 
 Pulls from upstream in all repositories.
@@ -314,6 +355,36 @@ sarge sync
 ```
 
 Runs git pull in each worktree (main and all work worktrees).
+
+## Database Commands
+
+### `sarge migrate`
+
+Manage database migrations for the tracking database. Migrations run automatically when the database is accessed, but these commands allow manual control.
+
+### `sarge migrate status`
+
+Show all applied database migrations.
+
+```bash
+sarge migrate status
+```
+
+### `sarge migrate up`
+
+Apply all pending database migrations.
+
+```bash
+sarge migrate up
+```
+
+### `sarge migrate rollback`
+
+Rollback the most recently applied database migration.
+
+```bash
+sarge migrate rollback
+```
 
 ## Linear Integration
 
@@ -410,7 +481,7 @@ Works have the following status states:
 
 ## ID Generation
 
-CO uses a hierarchical ID system:
+Sarge uses a hierarchical ID system:
 
 - **Work IDs**: Content-based hash (e.g., `w-8xa`)
   - Generated from branch name + project + timestamp


### PR DESCRIPTION
## Summary

- Fix stale "CO" references to "Sarge" in README and cli-reference
- Fix incorrect precondition on `work pr` ("completed" → "idle", matching the actual `StatusIdle` check in code)
- Remove phantom flags (`--auto-add`, `--min-priority`) and ghost command (`task set-review-epic`) that no longer exist in code
- Add missing flags and undocumented commands (`work console`, `work claude`, `work import-pr`, `plan`, `migrate`)
- Add "Create Issues" and "Monitor and Merge" steps to Quick Start for a complete onboarding flow

## Test plan

- [x] Verify all documented commands match `sarge --help` and subcommand `--help` output
- [x] Walk through Quick Start as a new user to confirm the flow makes sense
- [x] Confirm no remaining "CO" or "co " references in docs (excluding `.co/` directory path which is the actual config dir name)