### PR TITLE
Add tests for pprof port functionality

### DIFF
--- a/internal/db/process_pprof_test.go
+++ b/internal/db/process_pprof_test.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdatePprofPort(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Register a process first
+	err := database.RegisterProcess(ctx, "test-proc", ProcessTypeControlPlane, nil, 12345)
+	require.NoError(t, err)
+
+	// Set pprof port
+	port := 9090
+	err = database.UpdatePprofPort(ctx, "test-proc", &port)
+	require.NoError(t, err)
+
+	// Verify port was stored
+	proc, err := database.GetControlPlaneProcess(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	require.NotNil(t, proc.PprofPort)
+	assert.Equal(t, 9090, *proc.PprofPort)
+
+	// Clear pprof port
+	err = database.UpdatePprofPort(ctx, "test-proc", nil)
+	require.NoError(t, err)
+
+	proc, err = database.GetControlPlaneProcess(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	assert.Nil(t, proc.PprofPort, "pprof port should be nil after clearing")
+}

--- a/internal/debug/pprof_test.go
+++ b/internal/debug/pprof_test.go
@@ -1,0 +1,22 @@
+package debug
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartPprof(t *testing.T) {
+	port, err := StartPprof()
+	require.NoError(t, err)
+	assert.Greater(t, port, 0, "expected a valid port number")
+
+	// Verify pprof endpoint is accessible
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/pprof/", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/internal/procmon/manager_test.go
+++ b/internal/procmon/manager_test.go
@@ -287,6 +287,39 @@ func TestGetControlPlaneProcess(t *testing.T) {
 	assert.Equal(t, db.ProcessTypeControlPlane, proc.ProcessType)
 }
 
+func TestSetPprofPort(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	m := NewManager(database, 100*time.Millisecond)
+	defer m.Stop()
+
+	err := m.RegisterControlPlane(ctx)
+	require.NoError(t, err)
+
+	// Set pprof port
+	port := 8080
+	err = m.SetPprofPort(ctx, &port)
+	require.NoError(t, err)
+
+	// Verify via GetControlPlaneProcess
+	proc, err := m.GetControlPlaneProcess(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	require.NotNil(t, proc.PprofPort)
+	assert.Equal(t, 8080, *proc.PprofPort)
+
+	// Clear pprof port
+	err = m.SetPprofPort(ctx, nil)
+	require.NoError(t, err)
+
+	proc, err = m.GetControlPlaneProcess(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	assert.Nil(t, proc.PprofPort)
+}
+
 func TestGetAllProcesses(t *testing.T) {
 	database, cleanup := setupTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the pprof port functionality introduced in #18.

## Changes

This PR adds three new test cases covering the pprof subsystem end-to-end:

### New Tests

- **`TestStartPprof`** (`internal/debug/pprof_test.go`): Verifies that `StartPprof()` starts a server on a valid port and that the `/debug/pprof/` endpoint responds with HTTP 200.

- **`TestUpdatePprofPort`** (`internal/db/process_pprof_test.go`): Tests the database layer — registers a process, sets a pprof port, verifies it's stored correctly, then clears it and confirms it becomes nil.

- **`TestSetPprofPort`** (`internal/procmon/manager_test.go`): Integration test through the process manager — registers a control plane process, sets/clears the pprof port via `Manager.SetPprofPort()`, and verifies state through `GetControlPlaneProcess()`.

## Issues Resolved

- **ac-c75.10**: Add tests for pprof port functionality
- **ac-c75.11**: Fix Lint failure (confirmed lint was already passing — no changes needed)

## Testing

All new tests pass locally:
```
go test ./internal/debug/ ./internal/db/ ./internal/procmon/ -run 'TestStartPprof|TestUpdatePprofPort|TestSetPprofPort' -v
```

## Notes

- No breaking changes
- Test-only PR — no production code modified
- Follows existing test patterns and uses the shared `setupTestDB` helper