### PR TITLE
Fix stuck orchestrator: self-evicting process with force-register and heartbeat eviction detection

### DIFF
--- a/cmd/orchestrate.go
+++ b/cmd/orchestrate.go
@@ -138,6 +138,13 @@ func runOrchestrate(cmd *cobra.Command, args []string) error {
 
 	// Main orchestration loop: poll for ready tasks and execute them
 	for {
+		// Check if we've been evicted by a new orchestrator taking over
+		select {
+		case <-procManager.EvictedCh():
+			fmt.Println("Orchestrator evicted by new process, shutting down gracefully.")
+			return nil
+		default:
+		}
 
 		// Check if theWork still exists (may have been destroyed)
 		theWork, err = proj.DB.GetWork(ctx, workID)

--- a/internal/control/loop.go
+++ b/internal/control/loop.go
@@ -79,6 +79,14 @@ func RunControlPlaneLoopWithControlPlane(ctx context.Context, proj *project.Proj
 			fmt.Println("\nControl plane stopped.")
 			return nil
 
+		case <-procManager.EvictedCh():
+			logging.Info("Control plane evicted by new process, shutting down gracefully")
+			if runningCount := asyncExecutor.RunningCount(); runningCount > 0 {
+				fmt.Printf("\nWaiting for %d async task(s) to complete...\n", runningCount)
+			}
+			fmt.Println("\nControl plane evicted, stopped.")
+			return nil
+
 		case event, ok := <-sub:
 			if !ok {
 				logging.Debug("Watcher subscription closed")

--- a/internal/db/process.go
+++ b/internal/db/process.go
@@ -58,25 +58,35 @@ func (db *DB) RegisterProcess(ctx context.Context, id, processType string, workI
 }
 
 // UpdateHeartbeat updates the heartbeat timestamp for a process.
-func (db *DB) UpdateHeartbeat(ctx context.Context, id string) error {
-	err := db.queries.UpdateHeartbeat(ctx, id)
+// Returns the number of rows affected (0 if the process record was deleted).
+func (db *DB) UpdateHeartbeat(ctx context.Context, id string) (int64, error) {
+	result, err := db.queries.UpdateHeartbeat(ctx, id)
 	if err != nil {
-		return fmt.Errorf("failed to update heartbeat: %w", err)
+		return 0, fmt.Errorf("failed to update heartbeat: %w", err)
 	}
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	return rows, nil
 }
 
 // UpdateHeartbeatWithTime updates the heartbeat timestamp for a process with an explicit time.
+// Returns the number of rows affected (0 if the process record was deleted).
 // This is useful for testing where time needs to be controlled.
-func (db *DB) UpdateHeartbeatWithTime(ctx context.Context, id string, t time.Time) error {
-	err := db.queries.UpdateHeartbeatWithTime(ctx, sqlc.UpdateHeartbeatWithTimeParams{
+func (db *DB) UpdateHeartbeatWithTime(ctx context.Context, id string, t time.Time) (int64, error) {
+	result, err := db.queries.UpdateHeartbeatWithTime(ctx, sqlc.UpdateHeartbeatWithTimeParams{
 		Heartbeat: t,
 		ID:        id,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update heartbeat: %w", err)
+		return 0, fmt.Errorf("failed to update heartbeat: %w", err)
 	}
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	return rows, nil
 }
 
 // IsOrchestratorAlive checks if an orchestrator for the given work ID has a recent heartbeat.
@@ -144,50 +154,16 @@ func (db *DB) UnregisterProcess(ctx context.Context, id string) error {
 	return nil
 }
 
-// CleanupStaleControlPlane removes any existing control plane record if its heartbeat is stale.
-// This is used before registering a new control plane to handle cases where
-// the previous control plane was killed without proper cleanup.
-// Returns nil if no control plane exists or if it was successfully cleaned up.
-// Returns an error if the control plane has a fresh heartbeat (likely still alive).
-func (db *DB) CleanupStaleControlPlane(ctx context.Context) error {
-	// Check if control plane has a fresh heartbeat
-	alive, err := db.IsControlPlaneAlive(ctx, DefaultStalenessThreshold)
-	if err != nil {
-		return fmt.Errorf("failed to check control plane status: %w", err)
-	}
-	if alive {
-		return fmt.Errorf("control plane has fresh heartbeat - refusing to cleanup")
-	}
-
-	// Heartbeat is stale or no record exists, safe to delete
-	err = db.queries.DeleteControlPlaneProcess(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to cleanup stale control plane: %w", err)
-	}
-	return nil
+// DeleteControlPlaneProcess unconditionally deletes any existing control plane record.
+// This is used before registering a new control plane to force-take the registration.
+func (db *DB) DeleteControlPlaneProcess(ctx context.Context) error {
+	return db.queries.DeleteControlPlaneProcess(ctx)
 }
 
-// CleanupStaleOrchestrator removes any existing orchestrator record for a work ID if its heartbeat is stale.
-// This is used before registering a new orchestrator to handle cases where
-// the previous orchestrator was killed without proper cleanup.
-// Returns nil if no orchestrator exists or if it was successfully cleaned up.
-// Returns an error if the orchestrator has a fresh heartbeat (likely still alive).
-func (db *DB) CleanupStaleOrchestrator(ctx context.Context, workID string) error {
-	// Check if orchestrator has a fresh heartbeat
-	alive, err := db.IsOrchestratorAlive(ctx, workID, DefaultStalenessThreshold)
-	if err != nil {
-		return fmt.Errorf("failed to check orchestrator status: %w", err)
-	}
-	if alive {
-		return fmt.Errorf("orchestrator for work %s has fresh heartbeat - refusing to cleanup", workID)
-	}
-
-	// Heartbeat is stale or no record exists, safe to delete
-	err = db.queries.DeleteOrchestratorByWorkID(ctx, sql.NullString{String: workID, Valid: true})
-	if err != nil {
-		return fmt.Errorf("failed to cleanup stale orchestrator: %w", err)
-	}
-	return nil
+// DeleteOrchestratorByWorkID unconditionally deletes any existing orchestrator record for a work ID.
+// This is used before registering a new orchestrator to force-take the registration.
+func (db *DB) DeleteOrchestratorByWorkID(ctx context.Context, workID string) error {
+	return db.queries.DeleteOrchestratorByWorkID(ctx, sql.NullString{String: workID, Valid: true})
 }
 
 // GetOrchestratorProcess retrieves the orchestrator process for a work ID.

--- a/internal/db/sqlc/processes.sql.go
+++ b/internal/db/sqlc/processes.sql.go
@@ -271,18 +271,17 @@ func (q *Queries) RegisterProcess(ctx context.Context, arg RegisterProcessParams
 	return err
 }
 
-const updateHeartbeat = `-- name: UpdateHeartbeat :exec
+const updateHeartbeat = `-- name: UpdateHeartbeat :execresult
 UPDATE processes
 SET heartbeat = CURRENT_TIMESTAMP
 WHERE id = ?
 `
 
-func (q *Queries) UpdateHeartbeat(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, updateHeartbeat, id)
-	return err
+func (q *Queries) UpdateHeartbeat(ctx context.Context, id string) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateHeartbeat, id)
 }
 
-const updateHeartbeatWithTime = `-- name: UpdateHeartbeatWithTime :exec
+const updateHeartbeatWithTime = `-- name: UpdateHeartbeatWithTime :execresult
 UPDATE processes
 SET heartbeat = ?
 WHERE id = ?
@@ -293,9 +292,8 @@ type UpdateHeartbeatWithTimeParams struct {
 	ID        string    `json:"id"`
 }
 
-func (q *Queries) UpdateHeartbeatWithTime(ctx context.Context, arg UpdateHeartbeatWithTimeParams) error {
-	_, err := q.db.ExecContext(ctx, updateHeartbeatWithTime, arg.Heartbeat, arg.ID)
-	return err
+func (q *Queries) UpdateHeartbeatWithTime(ctx context.Context, arg UpdateHeartbeatWithTimeParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateHeartbeatWithTime, arg.Heartbeat, arg.ID)
 }
 
 const updatePprofPort = `-- name: UpdatePprofPort :exec

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -160,8 +160,8 @@ type Querier interface {
 	StartBead(ctx context.Context, arg StartBeadParams) error
 	StartTask(ctx context.Context, arg StartTaskParams) (int64, error)
 	StartWork(ctx context.Context, arg StartWorkParams) (int64, error)
-	UpdateHeartbeat(ctx context.Context, id string) error
-	UpdateHeartbeatWithTime(ctx context.Context, arg UpdateHeartbeatWithTimeParams) error
+	UpdateHeartbeat(ctx context.Context, id string) (sql.Result, error)
+	UpdateHeartbeatWithTime(ctx context.Context, arg UpdateHeartbeatWithTimeParams) (sql.Result, error)
 	UpdateMigrationDownSQL(ctx context.Context, arg UpdateMigrationDownSQLParams) error
 	UpdatePprofPort(ctx context.Context, arg UpdatePprofPortParams) error
 	UpdateScheduledTaskTime(ctx context.Context, arg UpdateScheduledTaskTimeParams) error

--- a/internal/procmon/manager.go
+++ b/internal/procmon/manager.go
@@ -28,6 +28,7 @@ type Manager struct {
 	stopCh    chan struct{}
 	stoppedCh chan struct{}
 	triggerCh chan chan error // For testing: trigger immediate heartbeat
+	evictedCh chan struct{}  // Closed when this process is evicted by a new one
 }
 
 // NewManager creates a new process manager.
@@ -49,7 +50,8 @@ func (m *Manager) SetNowFunc(f func() time.Time) {
 }
 
 // RegisterControlPlane registers this process as the control plane.
-// Any existing stale control plane record is cleaned up first.
+// Any existing control plane record is unconditionally deleted first (force-takeover).
+// The old process will detect eviction on its next heartbeat and shut down.
 // Returns an error if registration fails.
 func (m *Manager) RegisterControlPlane(ctx context.Context) error {
 	m.mu.Lock()
@@ -59,11 +61,10 @@ func (m *Manager) RegisterControlPlane(ctx context.Context) error {
 		return fmt.Errorf("manager already running")
 	}
 
-	// Clean up any stale control plane record before registering
-	// This handles cases where a previous control plane was killed without cleanup
-	if err := m.db.CleanupStaleControlPlane(ctx); err != nil {
-		logging.Warn("failed to cleanup stale control plane", "error", err)
-		// Continue anyway - the registration will fail if there's a real conflict
+	// Force-delete any existing control plane record before registering
+	// The old process (if still alive) will detect eviction on its next heartbeat
+	if err := m.db.DeleteControlPlaneProcess(ctx); err != nil {
+		logging.Warn("failed to delete existing control plane", "error", err)
 	}
 
 	m.id = uuid.New().String()
@@ -80,7 +81,8 @@ func (m *Manager) RegisterControlPlane(ctx context.Context) error {
 }
 
 // RegisterOrchestrator registers this process as an orchestrator for the given work ID.
-// Any existing stale orchestrator record for this work ID is cleaned up first.
+// Any existing orchestrator record for this work ID is unconditionally deleted first (force-takeover).
+// The old process will detect eviction on its next heartbeat and shut down.
 // Returns an error if registration fails.
 func (m *Manager) RegisterOrchestrator(ctx context.Context, workID string) error {
 	m.mu.Lock()
@@ -90,11 +92,10 @@ func (m *Manager) RegisterOrchestrator(ctx context.Context, workID string) error
 		return fmt.Errorf("manager already running")
 	}
 
-	// Clean up any stale orchestrator record before registering
-	// This handles cases where a previous orchestrator was killed without cleanup
-	if err := m.db.CleanupStaleOrchestrator(ctx, workID); err != nil {
-		logging.Warn("failed to cleanup stale orchestrator", "workID", workID, "error", err)
-		// Continue anyway - the registration will fail if there's a real conflict
+	// Force-delete any existing orchestrator record before registering
+	// The old process (if still alive) will detect eviction on its next heartbeat
+	if err := m.db.DeleteOrchestratorByWorkID(ctx, workID); err != nil {
+		logging.Warn("failed to delete existing orchestrator", "workID", workID, "error", err)
 	}
 
 	m.id = uuid.New().String()
@@ -116,6 +117,7 @@ func (m *Manager) startHeartbeat() {
 	m.stopCh = make(chan struct{})
 	m.stoppedCh = make(chan struct{})
 	m.triggerCh = make(chan chan error)
+	m.evictedCh = make(chan struct{})
 
 	go func() {
 		defer close(m.stoppedCh)
@@ -127,15 +129,33 @@ func (m *Manager) startHeartbeat() {
 			case <-m.stopCh:
 				return
 			case <-ticker.C:
-				if err := m.db.UpdateHeartbeatWithTime(context.Background(), m.id, m.nowFunc()); err != nil {
+				rows, err := m.db.UpdateHeartbeatWithTime(context.Background(), m.id, m.nowFunc())
+				if err != nil {
 					logging.Warn("failed to update heartbeat", "id", m.id, "error", err)
+				} else if rows == 0 {
+					logging.Info("process evicted: heartbeat row deleted by new process", "id", m.id)
+					close(m.evictedCh)
+					return
 				}
 			case resultCh := <-m.triggerCh:
-				err := m.db.UpdateHeartbeatWithTime(context.Background(), m.id, m.nowFunc())
+				rows, err := m.db.UpdateHeartbeatWithTime(context.Background(), m.id, m.nowFunc())
+				if err == nil && rows == 0 {
+					logging.Info("process evicted: heartbeat row deleted by new process", "id", m.id)
+					close(m.evictedCh)
+					resultCh <- nil
+					return
+				}
 				resultCh <- err
 			}
 		}
 	}()
+}
+
+// EvictedCh returns a channel that is closed when this process has been evicted
+// by a new process taking over its registration. Callers should select on this
+// channel to gracefully shut down when evicted.
+func (m *Manager) EvictedCh() <-chan struct{} {
+	return m.evictedCh
 }
 
 // TriggerHeartbeat forces an immediate heartbeat update and waits for it to complete.

--- a/internal/procmon/manager_test.go
+++ b/internal/procmon/manager_test.go
@@ -218,7 +218,7 @@ func TestCleanupStaleProcessRecords(t *testing.T) {
 
 	// Set heartbeat to 60 seconds ago to simulate a stale process
 	oldTime := time.Now().Add(-60 * time.Second)
-	err = database.UpdateHeartbeatWithTime(ctx, "stale-id", oldTime)
+	_, err = database.UpdateHeartbeatWithTime(ctx, "stale-id", oldTime)
 	require.NoError(t, err)
 
 	// Verify the stale process exists
@@ -318,4 +318,199 @@ func TestGetAllProcesses(t *testing.T) {
 	procs, err = m.GetAllProcesses(ctx)
 	require.NoError(t, err)
 	assert.Len(t, procs, 3, "expected 3 processes (1 control plane + 2 orchestrators)")
+}
+
+// --- Eviction tests ---
+
+func TestOrchestratorEvictionDetection(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Register Manager A as orchestrator
+	mA := NewManager(database, time.Hour)
+	err := mA.RegisterOrchestrator(ctx, "work-123")
+	require.NoError(t, err)
+	defer mA.Stop()
+
+	// Force-delete A's record (simulating another process taking over)
+	err = database.DeleteOrchestratorByWorkID(ctx, "work-123")
+	require.NoError(t, err)
+
+	// Trigger heartbeat on A — should detect eviction
+	err = mA.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	// evictedCh should be closed
+	select {
+	case <-mA.EvictedCh():
+		// Expected: eviction detected
+	case <-time.After(time.Second):
+		t.Fatal("expected evictedCh to be closed after heartbeat row was deleted")
+	}
+}
+
+func TestOrchestratorRestartEviction(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Register Manager A as orchestrator for work-123
+	mA := NewManager(database, time.Hour)
+	err := mA.RegisterOrchestrator(ctx, "work-123")
+	require.NoError(t, err)
+	defer mA.Stop()
+
+	// Register Manager B as orchestrator for same work-123 (force-takes over)
+	mB := NewManager(database, time.Hour)
+	err = mB.RegisterOrchestrator(ctx, "work-123")
+	require.NoError(t, err)
+	defer mB.Stop()
+
+	// Trigger A's heartbeat — should detect eviction
+	err = mA.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	select {
+	case <-mA.EvictedCh():
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("expected mA to detect eviction after mB took over")
+	}
+
+	// B should NOT be evicted
+	select {
+	case <-mB.EvictedCh():
+		t.Fatal("mB should not be evicted")
+	default:
+		// Expected: B is still running
+	}
+}
+
+func TestOrchestratorNormalOperation(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	m := NewManager(database, time.Hour)
+	defer m.Stop()
+
+	err := m.RegisterOrchestrator(ctx, "work-456")
+	require.NoError(t, err)
+
+	// Trigger heartbeat — should NOT trigger eviction
+	err = m.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	select {
+	case <-m.EvictedCh():
+		t.Fatal("should not be evicted during normal operation")
+	default:
+		// Expected
+	}
+}
+
+func TestOrchestratorGracefulStopStillWorks(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	m := NewManager(database, time.Hour)
+	err := m.RegisterOrchestrator(ctx, "work-789")
+	require.NoError(t, err)
+
+	// Stop gracefully
+	m.Stop()
+
+	// Process should be unregistered
+	proc, err := database.GetOrchestratorProcess(ctx, "work-789")
+	require.NoError(t, err)
+	assert.Nil(t, proc, "process should be nil after graceful stop")
+}
+
+func TestControlPlaneEvictionDetection(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Register Manager A as control plane
+	mA := NewManager(database, time.Hour)
+	err := mA.RegisterControlPlane(ctx)
+	require.NoError(t, err)
+	defer mA.Stop()
+
+	// Force-delete A's record
+	err = database.DeleteControlPlaneProcess(ctx)
+	require.NoError(t, err)
+
+	// Trigger heartbeat on A — should detect eviction
+	err = mA.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	select {
+	case <-mA.EvictedCh():
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("expected evictedCh to be closed after control plane row was deleted")
+	}
+}
+
+func TestControlPlaneRestartEviction(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Register Manager A as control plane
+	mA := NewManager(database, time.Hour)
+	err := mA.RegisterControlPlane(ctx)
+	require.NoError(t, err)
+	defer mA.Stop()
+
+	// Register Manager B as control plane (force-takes over)
+	mB := NewManager(database, time.Hour)
+	err = mB.RegisterControlPlane(ctx)
+	require.NoError(t, err)
+	defer mB.Stop()
+
+	// Trigger A's heartbeat — should detect eviction
+	err = mA.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	select {
+	case <-mA.EvictedCh():
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("expected mA to detect eviction after mB took over")
+	}
+
+	// B should NOT be evicted
+	select {
+	case <-mB.EvictedCh():
+		t.Fatal("mB should not be evicted")
+	default:
+		// Expected
+	}
+}
+
+func TestControlPlaneNormalOperation(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	m := NewManager(database, time.Hour)
+	defer m.Stop()
+
+	err := m.RegisterControlPlane(ctx)
+	require.NoError(t, err)
+
+	// Trigger heartbeat — should NOT trigger eviction
+	err = m.TriggerHeartbeat()
+	require.NoError(t, err)
+
+	select {
+	case <-m.EvictedCh():
+		t.Fatal("should not be evicted during normal operation")
+	default:
+		// Expected
+	}
 }

--- a/sql/queries/processes.sql
+++ b/sql/queries/processes.sql
@@ -6,12 +6,12 @@ ON CONFLICT (id) DO UPDATE SET
     hostname = excluded.hostname,
     heartbeat = CURRENT_TIMESTAMP;
 
--- name: UpdateHeartbeat :exec
+-- name: UpdateHeartbeat :execresult
 UPDATE processes
 SET heartbeat = CURRENT_TIMESTAMP
 WHERE id = ?;
 
--- name: UpdateHeartbeatWithTime :exec
+-- name: UpdateHeartbeatWithTime :execresult
 UPDATE processes
 SET heartbeat = ?
 WHERE id = ?;


### PR DESCRIPTION
## Summary

Fixes the issue where a killed orchestrator leaves a stale process record in the database, preventing a new orchestrator from starting (`UNIQUE constraint failed: processes.work_id`).

## Problem

When an orchestrator (or control plane) is killed without proper cleanup, its process record remains in the database. On restart, registration fails due to a unique constraint on `work_id`. The previous approach tried to clean up stale records by checking heartbeat freshness, but this was unreliable — if the process was killed recently, the heartbeat would still appear fresh, and cleanup would be refused.

## Solution

Implements a **self-evicting orchestrator** pattern with two parts:

### Part 1: Force-register new process
- On registration, **unconditionally delete** any existing process record for the same work ID (orchestrator) or process type (control plane) before inserting the new one.
- Replaces the old `CleanupStaleOrchestrator` / `CleanupStaleControlPlane` methods that checked heartbeat freshness — those are removed entirely.
- This guarantees registration always succeeds.

### Part 2: Old process detects eviction via heartbeat
- The heartbeat loop now checks `RowsAffected()` after each heartbeat update.
- If 0 rows were affected, the process record was deleted by a new process taking over → the old process has been **evicted**.
- On eviction, closes an `evictedCh` channel that callers can select on to shut down gracefully.
- Both the orchestrator loop (`cmd/orchestrate.go`) and control plane loop (`internal/control/loop.go`) select on `EvictedCh()` for graceful shutdown.

## Changes

| File | Change |
|------|--------|
| `sql/queries/processes.sql` | Changed `UpdateHeartbeat` and `UpdateHeartbeatWithTime` from `:exec` to `:execresult` to return `sql.Result` |
| `internal/db/sqlc/processes.sql.go` | Regenerated sqlc — heartbeat queries now return `(sql.Result, error)` |
| `internal/db/sqlc/querier.go` | Updated interface to match new return types |
| `internal/db/process.go` | `UpdateHeartbeat`/`UpdateHeartbeatWithTime` now return `(int64, error)` with rows affected; removed `CleanupStaleOrchestrator`/`CleanupStaleControlPlane`; added `DeleteControlPlaneProcess`/`DeleteOrchestratorByWorkID` as simple unconditional deletes |
| `internal/procmon/manager.go` | Added `evictedCh` channel and `EvictedCh()` method; heartbeat loop detects 0 rows → closes evictedCh; registration uses force-delete instead of stale cleanup |
| `cmd/orchestrate.go` | Main loop selects on `procManager.EvictedCh()` for graceful shutdown |
| `internal/control/loop.go` | Control plane loop selects on `procManager.EvictedCh()` for graceful shutdown |
| `internal/procmon/manager_test.go` | Added 7 eviction tests covering orchestrator and control plane scenarios |

## Issues Resolved

- **ac-3ao**: Orchestrator stuck — root issue
- **ac-3ao.5**: Self-evicting orchestrator with force-register and heartbeat eviction detection

## Testing

7 new tests added in `internal/procmon/manager_test.go`:

1. **TestOrchestratorEvictionDetection** — Force-delete record, trigger heartbeat, verify eviction detected
2. **TestOrchestratorRestartEviction** — Register A then B for same work, verify A detects eviction, B does not
3. **TestOrchestratorNormalOperation** — Normal heartbeat does not trigger eviction
4. **TestOrchestratorGracefulStopStillWorks** — Graceful stop still unregisters properly
5. **TestControlPlaneEvictionDetection** — Same as #1 for control plane
6. **TestControlPlaneRestartEviction** — Same as #2 for control plane
7. **TestControlPlaneNormalOperation** — Same as #3 for control plane

All tests use in-memory SQLite, no OS mocking required.

## Breaking Changes

- `db.UpdateHeartbeat()` and `db.UpdateHeartbeatWithTime()` now return `(int64, error)` instead of `error`
- `db.CleanupStaleOrchestrator()` and `db.CleanupStaleControlPlane()` are removed (replaced by unconditional delete)
- `sqlc.Querier` interface updated: `UpdateHeartbeat` and `UpdateHeartbeatWithTime` return `(sql.Result, error)`
