### PR TITLE
perf: compile regex patterns once at package level in extractGitHubID

### DIFF
--- a/internal/feedback/integration.go
+++ b/internal/feedback/integration.go
@@ -13,6 +13,14 @@ import (
 	"github.com/sargehq/sarge/internal/project"
 )
 
+// Package-level compiled regexes for extractGitHubID
+var (
+	reviewCommentIDPattern = regexp.MustCompile(`#discussion_r(\d+)`)
+	issueCommentIDPattern  = regexp.MustCompile(`#issuecomment-(\d+)`)
+	prNumberPattern        = regexp.MustCompile(`/pull/(\d+)`)
+	issueNumberPattern     = regexp.MustCompile(`/issues/(\d+)`)
+)
+
 // BeadInfo represents information for creating a bead from feedback.
 type BeadInfo struct {
 	Title       string
@@ -142,26 +150,22 @@ func (i *Integration) CreateBeadFromFeedback(ctx context.Context, beadDir string
 // returns "review-comment-789"
 func extractGitHubID(url string) string {
 	// Try to extract review comment ID (e.g., #discussion_r123456)
-	reviewCommentRe := regexp.MustCompile(`#discussion_r(\d+)`)
-	if matches := reviewCommentRe.FindStringSubmatch(url); len(matches) > 1 {
+	if matches := reviewCommentIDPattern.FindStringSubmatch(url); len(matches) > 1 {
 		return "review-comment-" + matches[1]
 	}
 
 	// Try to extract regular comment ID (e.g., #issuecomment-456789)
-	commentRe := regexp.MustCompile(`#issuecomment-(\d+)`)
-	if matches := commentRe.FindStringSubmatch(url); len(matches) > 1 {
+	if matches := issueCommentIDPattern.FindStringSubmatch(url); len(matches) > 1 {
 		return "comment-" + matches[1]
 	}
 
 	// Try to extract PR number
-	prRe := regexp.MustCompile(`/pull/(\d+)`)
-	if matches := prRe.FindStringSubmatch(url); len(matches) > 1 {
+	if matches := prNumberPattern.FindStringSubmatch(url); len(matches) > 1 {
 		return "pr-" + matches[1]
 	}
 
 	// Try to extract issue number
-	issueRe := regexp.MustCompile(`/issues/(\d+)`)
-	if matches := issueRe.FindStringSubmatch(url); len(matches) > 1 {
+	if matches := issueNumberPattern.FindStringSubmatch(url); len(matches) > 1 {
 		return "issue-" + matches[1]
 	}
 


### PR DESCRIPTION
## Summary

Move four regex compilations from inside `extractGitHubID()` to package-level `var` declarations, so they are compiled once at program startup rather than on every function call.

## Changes

**`internal/feedback/integration.go`**

- Added four package-level compiled regex variables:
  - `reviewCommentIDPattern` — matches `#discussion_r<digits>`
  - `issueCommentIDPattern` — matches `#issuecomment-<digits>`
  - `prNumberPattern` — matches `/pull/<digits>`
  - `issueNumberPattern` — matches `/issues/<digits>`
- Updated `extractGitHubID()` to use the pre-compiled patterns instead of calling `regexp.MustCompile()` inline on each invocation.

## Motivation

`regexp.MustCompile` is relatively expensive. Since these patterns are constant, compiling them once at package level is the standard Go idiom and avoids unnecessary allocations on every call to `extractGitHubID`.

## Issues Resolved

- Resolves **ac-ees.6**: Compile regex once at package level in `extractGitHubID`

## Testing

- Existing tests pass (`go test ./internal/feedback/...`).
- No behavioral changes — this is a pure refactor for performance.
