### PR TITLE
fix(sarge-complete): skip sarge complete on user interrupt (Esc)

### DIFF
--- a/.pi/extensions/sarge-complete.ts
+++ b/.pi/extensions/sarge-complete.ts
@@ -3,9 +3,22 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 export default function (pi: ExtensionAPI) {
   // Primary safety net: when the agent finishes processing, check if the task
   // is still in 'processing' status and call sarge complete if so.
-  pi.on("agent_end", async (_event, _ctx) => {
+  pi.on("agent_end", async (event, _ctx) => {
     const taskID = process.env.SARGE_TASK_ID;
     if (!taskID) return;
+
+    // Don't call sarge complete if the agent was interrupted by the user (Esc).
+    // When interrupted, the last assistant message has stopReason === "aborted".
+    // The user may want to continue the session, so leave the task in processing.
+    const lastAssistant = event.messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === "assistant") as
+      | { role: "assistant"; stopReason: string }
+      | undefined;
+    if (lastAssistant?.stopReason === "aborted") {
+      return;
+    }
 
     try {
       // Check if task is still processing by running sarge task show

--- a/internal/skill/extensions/sarge-complete.ts
+++ b/internal/skill/extensions/sarge-complete.ts
@@ -3,9 +3,22 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 export default function (pi: ExtensionAPI) {
   // Primary safety net: when the agent finishes processing, check if the task
   // is still in 'processing' status and call sarge complete if so.
-  pi.on("agent_end", async (_event, _ctx) => {
+  pi.on("agent_end", async (event, _ctx) => {
     const taskID = process.env.SARGE_TASK_ID;
     if (!taskID) return;
+
+    // Don't call sarge complete if the agent was interrupted by the user (Esc).
+    // When interrupted, the last assistant message has stopReason === "aborted".
+    // The user may want to continue the session, so leave the task in processing.
+    const lastAssistant = event.messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === "assistant") as
+      | { role: "assistant"; stopReason: string }
+      | undefined;
+    if (lastAssistant?.stopReason === "aborted") {
+      return;
+    }
 
     try {
       // Check if task is still processing by running sarge task show


### PR DESCRIPTION
## Problem

Pressing Escape while pi was busy working triggered `agent_end`, which caused the `sarge-complete` extension to call `sarge complete --error` — marking the task failed even though the user just wanted a temporary interrupt.

## Root Cause

`agent_end` fires for both normal completion and user interrupts. There's no explicit `interrupted` flag, but the last assistant message in `event.messages` has `stopReason === "aborted"` when the user presses Esc, vs `"stop"` / `"toolUse"` on natural completion.

## Fix

In the `agent_end` handler, check the last assistant message's `stopReason` before calling `sarge complete`. If it's `"aborted"`, return early and leave the task in `processing` so the user can continue working.

```typescript
const lastAssistant = event.messages
  .slice()
  .reverse()
  .find((m) => m.role === "assistant") as
  | { role: "assistant"; stopReason: string }
  | undefined;
if (lastAssistant?.stopReason === "aborted") {
  return; // User interrupted — leave task in processing
}
```

The `session_shutdown` safety-net (pi actually exiting) is unaffected and still calls `sarge complete --error` when appropriate.