### PR TITLE
feat: reuse existing zellij session when running inside one

### DIFF
--- a/internal/control/spawn.go
+++ b/internal/control/spawn.go
@@ -95,25 +95,32 @@ func ensureControlPlaneZmxWith(ctx context.Context, proj *project.Project, zmxCl
 }
 
 // ensureControlPlaneZellij ensures the control plane is running in a zellij session.
+// If we're inside a zellij session, reuses it. Otherwise creates "sarge-<project>".
 func ensureControlPlaneZellij(ctx context.Context, proj *project.Project) (*InitResult, error) {
 	projectName := proj.Config.Project.Name
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
+	insideSession := zellij.CurrentSessionName() != ""
 	zc := zellij.New()
 
 	result := &InitResult{
 		SessionName: sessionName,
 	}
 
-	// Ensure session exists with control plane as the initial tab
-	sessionCreated, err := zc.EnsureSessionWithCommand(ctx, sessionName, ControlPlaneTabName, proj.Root, "sarge", []string{"control", "--root", proj.Root})
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure zellij session: %w", err)
-	}
-	result.SessionCreated = sessionCreated
+	if insideSession {
+		// We're inside a zellij session — it already exists, just ensure the control plane tab
+		logging.Debug("Inside zellij session, reusing for control plane", "sessionName", sessionName)
+	} else {
+		// Not inside a session — create one if needed
+		sessionCreated, err := zc.EnsureSessionWithCommand(ctx, sessionName, ControlPlaneTabName, proj.Root, "sarge", []string{"control", "--root", proj.Root})
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure zellij session: %w", err)
+		}
+		result.SessionCreated = sessionCreated
 
-	if sessionCreated {
-		logging.Debug("New zellij session created with control plane", "sessionName", sessionName)
-		return result, nil
+		if sessionCreated {
+			logging.Debug("New zellij session created with control plane", "sessionName", sessionName)
+			return result, nil
+		}
 	}
 
 	// Session existed - check if control plane tab exists
@@ -158,7 +165,7 @@ func ensureControlPlaneZellij(ctx context.Context, proj *project.Project) (*Init
 func spawnControlPlane(ctx context.Context, proj *project.Project) error {
 	projectName := proj.Config.Project.Name
 	projectRoot := proj.Root
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 	zc := zellij.New()
 
 	logging.Debug("spawnControlPlane started", "sessionName", sessionName, "projectRoot", projectRoot)

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -1098,9 +1098,7 @@ another = "also untouched"
 	require.Contains(t, content, `type = "zmx"`)
 }
 
-
 func TestResolveSessionName_NoZellijEnv(t *testing.T) {
-	// Ensure ZELLIJ_SESSION_NAME is unset
 	t.Setenv("ZELLIJ_SESSION_NAME", "")
 	result := ResolveSessionName("myproject")
 	require.Equal(t, "sarge-myproject", result)
@@ -1110,11 +1108,4 @@ func TestResolveSessionName_InsideZellijSession(t *testing.T) {
 	t.Setenv("ZELLIJ_SESSION_NAME", "my-daily-session")
 	result := ResolveSessionName("myproject")
 	require.Equal(t, "my-daily-session", result)
-}
-
-func TestResolveSessionName_FallsBackToDefault(t *testing.T) {
-	// Explicitly unset
-	os.Unsetenv("ZELLIJ_SESSION_NAME")
-	result := ResolveSessionName("cool-project")
-	require.Equal(t, "sarge-cool-project", result)
 }

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -1098,3 +1098,23 @@ another = "also untouched"
 	require.Contains(t, content, `type = "zmx"`)
 }
 
+
+func TestResolveSessionName_NoZellijEnv(t *testing.T) {
+	// Ensure ZELLIJ_SESSION_NAME is unset
+	t.Setenv("ZELLIJ_SESSION_NAME", "")
+	result := ResolveSessionName("myproject")
+	require.Equal(t, "sarge-myproject", result)
+}
+
+func TestResolveSessionName_InsideZellijSession(t *testing.T) {
+	t.Setenv("ZELLIJ_SESSION_NAME", "my-daily-session")
+	result := ResolveSessionName("myproject")
+	require.Equal(t, "my-daily-session", result)
+}
+
+func TestResolveSessionName_FallsBackToDefault(t *testing.T) {
+	// Explicitly unset
+	os.Unsetenv("ZELLIJ_SESSION_NAME")
+	result := ResolveSessionName("cool-project")
+	require.Equal(t, "sarge-cool-project", result)
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -32,10 +32,23 @@ const (
 	RepoTypeGitHub = "github"
 )
 
-// SessionNameForProject returns the zellij session name for a specific project.
-// This is used consistently across the codebase for session management.
+// SessionNameForProject returns the default zellij session name for a project.
+// This always returns "sarge-<project>" regardless of whether we're inside a zellij session.
+// Most callers should use ResolveSessionName instead.
 func SessionNameForProject(projectName string) string {
 	return fmt.Sprintf("sarge-%s", projectName)
+}
+
+// ResolveSessionName returns the zellij session to use for tab management.
+// If we're already inside a zellij session (detected via $ZELLIJ_SESSION_NAME),
+// it reuses that session. Otherwise, it returns the default "sarge-<project>" name.
+// This allows sarge to create tabs in the user's existing zellij session
+// rather than forcing a separate session.
+func ResolveSessionName(projectName string) string {
+	if current := os.Getenv("ZELLIJ_SESSION_NAME"); current != "" {
+		return current
+	}
+	return SessionNameForProject(projectName)
 }
 
 // FormatTabName formats a tab name with an optional friendly name.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sargehq/sarge/internal/beans"
+	"github.com/sargehq/sarge/internal/zellij"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/git"
 	"github.com/sargehq/sarge/internal/logging"
@@ -32,10 +33,9 @@ const (
 	RepoTypeGitHub = "github"
 )
 
-// SessionNameForProject returns the default zellij session name for a project.
+// sessionNameForProject returns the default zellij session name for a project.
 // This always returns "sarge-<project>" regardless of whether we're inside a zellij session.
-// Most callers should use ResolveSessionName instead.
-func SessionNameForProject(projectName string) string {
+func sessionNameForProject(projectName string) string {
 	return fmt.Sprintf("sarge-%s", projectName)
 }
 
@@ -45,10 +45,10 @@ func SessionNameForProject(projectName string) string {
 // This allows sarge to create tabs in the user's existing zellij session
 // rather than forcing a separate session.
 func ResolveSessionName(projectName string) string {
-	if current := os.Getenv("ZELLIJ_SESSION_NAME"); current != "" {
+	if current := zellij.CurrentSessionName(); current != "" {
 		return current
 	}
-	return SessionNameForProject(projectName)
+	return sessionNameForProject(projectName)
 }
 
 // FormatTabName formats a tab name with an optional friendly name.

--- a/internal/work/orchestrator.go
+++ b/internal/work/orchestrator.go
@@ -205,7 +205,7 @@ func (m *DefaultOrchestratorManager) terminateWorkTabsZmx(ctx context.Context, w
 
 // terminateWorkTabsZellij terminates all zellij tabs associated with a work unit.
 func (m *DefaultOrchestratorManager) terminateWorkTabsZellij(ctx context.Context, workID string, projectName string, w io.Writer) error {
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 
 	logging.Debug("TerminateWorkTabs starting",
 		"work_id", workID,
@@ -351,7 +351,7 @@ func (m *DefaultOrchestratorManager) spawnWorkOrchestratorZmx(ctx context.Contex
 // spawnWorkOrchestratorZellij creates a zellij tab running the orchestrate command.
 func (m *DefaultOrchestratorManager) spawnWorkOrchestratorZellij(ctx context.Context, workID string, projectName string, workDir string, friendlyName string, w io.Writer) error {
 	logging.Debug("SpawnWorkOrchestrator called", "workID", workID, "projectName", projectName, "workDir", workDir)
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 	tabName := project.FormatTabName("orch", workID, friendlyName)
 
 	// Verify session exists - callers must initialize it with control plane
@@ -415,7 +415,7 @@ func (m *DefaultOrchestratorManager) EnsureWorkOrchestrator(ctx context.Context,
 	} else {
 		tabName := project.FormatTabName("orch", workID, friendlyName)
 		displayTabName = tabName
-		sessionName := project.SessionNameForProject(projectName)
+		sessionName := project.ResolveSessionName(projectName)
 		sessionExists = m.tabExists(ctx, sessionName, tabName)
 	}
 

--- a/internal/work/tabs.go
+++ b/internal/work/tabs.go
@@ -153,7 +153,7 @@ func (m *DefaultOrchestratorManager) openConsoleZmx(ctx context.Context, workID 
 
 // openConsoleZellij creates a zellij tab with a shell in the work's worktree.
 func (m *DefaultOrchestratorManager) openConsoleZellij(ctx context.Context, workID string, projectName string, workDir string, friendlyName string, hooksEnv []string, w io.Writer) error {
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 	tabName := project.FormatTabName("console", workID, friendlyName)
 
 	// Verify session exists - callers must initialize it with control plane
@@ -308,7 +308,7 @@ func (m *DefaultOrchestratorManager) openAgentSessionZellij(ctx context.Context,
 		agentType = cfg.Agent.Type
 	}
 
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 	tabName := project.FormatTabName("agent", workID, friendlyName)
 
 	// Verify session exists - callers must initialize it with control plane
@@ -385,7 +385,7 @@ func (m *DefaultOrchestratorManager) spawnPlanSessionZmx(ctx context.Context, be
 
 // spawnPlanSessionZellij creates a zellij tab running the plan command.
 func (m *DefaultOrchestratorManager) spawnPlanSessionZellij(ctx context.Context, beanID string, projectName string, mainRepoPath string, w io.Writer) error {
-	sessionName := project.SessionNameForProject(projectName)
+	sessionName := project.ResolveSessionName(projectName)
 	tabName := PlanTabName(beanID)
 
 	// Verify session exists - callers must initialize it with control plane


### PR DESCRIPTION
## Summary

When sarge is launched from inside an existing zellij session, it now reuses that session for all tab management instead of creating a separate `sarge-<project>` session.

## Changes

- **`internal/project/project.go`**: Added `ResolveSessionName()` which checks `$ZELLIJ_SESSION_NAME` to detect if we're already inside a zellij session. If so, reuses it; otherwise falls back to the default `sarge-<project>` naming.
- **`internal/control/spawn.go`**: Updated control plane initialization to skip session creation when already inside a zellij session, and just ensure the control plane tab.
- **`internal/work/orchestrator.go`**: Updated all session name references to use `ResolveSessionName()`.
- **`internal/work/tabs.go`**: Updated console, agent, and plan tab creation to use `ResolveSessionName()`.
- **`internal/project/config_test.go`**: Added tests for `ResolveSessionName` covering both inside-session and outside-session cases.

## Motivation

Previously, running `sarge` inside an existing zellij session would create a *second* session (`sarge-<project>`), forcing users to switch between sessions. This was awkward for users who already have a zellij workflow. Now sarge integrates naturally into the user's existing session by creating tabs there directly.