### PR TITLE
fix: beans-prime extension runs only once per session

### DIFF
--- a/.beans/main-s8ng--fix-beans-prime-extension-running-on-every-prompt.md
+++ b/.beans/main-s8ng--fix-beans-prime-extension-running-on-every-prompt.md
@@ -1,0 +1,13 @@
+---
+# main-s8ng
+title: Fix beans-prime extension running on every prompt
+status: completed
+type: bug
+priority: normal
+created_at: 2026-02-25T05:28:43Z
+updated_at: 2026-02-25T05:28:47Z
+---
+
+The beans-prime.ts pi extension uses before_agent_start which fires on every user prompt, causing beans prime to run repeatedly. Added a hasPrimed guard so it only runs once per session.
+
+## Summary of Changes\n\nAdded a `hasPrimed` guard to `internal/agentsetup/extensions/beans-prime.ts` so `beans prime` only runs once per session (on the first `before_agent_start` event), not on every user prompt.

--- a/.pi/extensions/beans-prime.ts
+++ b/.pi/extensions/beans-prime.ts
@@ -1,9 +1,14 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
-  // Run `beans prime` at session start and inject the output as context for the LLM.
+  let hasPrimed = false;
+
+  // Run `beans prime` once at the start of the session and inject the output as context for the LLM.
   // This replicates what the beans Claude Code hook does automatically.
   pi.on("before_agent_start", async (_event, _ctx) => {
+    if (hasPrimed) return;
+    hasPrimed = true;
+
     const result = await pi.exec("beans", ["prime"], { timeout: 10000 });
 
     // Exit code 1 with no output usually means no beans project — skip silently.

--- a/internal/agentsetup/extensions/beans-prime.ts
+++ b/internal/agentsetup/extensions/beans-prime.ts
@@ -1,9 +1,15 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
-  // Run `beans prime` at session start and inject the output as context for the LLM.
-  // This replicates what the beans Claude Code hook does automatically.
+  let hasPrimed = false;
+
+  // Run `beans prime` once per session and inject the output as context for the LLM.
+  // Uses before_agent_start (not session_start) so we can return a message for the LLM.
+  // The hasPrimed guard ensures it only runs on the first prompt, not every prompt.
   pi.on("before_agent_start", async (_event, _ctx) => {
+    if (hasPrimed) return;
+    hasPrimed = true;
+
     const result = await pi.exec("beans", ["prime"], { timeout: 10000 });
 
     // Exit code 1 with no output usually means no beans project — skip silently.


### PR DESCRIPTION
The `before_agent_start` event fires on every user prompt, causing `beans prime` to execute repeatedly throughout a session. Added a `hasPrimed` guard so it only runs on the first prompt.

**Root cause:** `before_agent_start` != `session_start`. It fires per-prompt, but we need `before_agent_start` (not `session_start`) because only it supports returning an injected message for the LLM.

**Fix:** Simple `hasPrimed` boolean guard in the extension closure.

Fixes: main-s8ng