### PR TITLE
Fix beans init failing during proj create

### DIFF
--- a/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
+++ b/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
@@ -1,0 +1,11 @@
+---
+# main-2ods
+title: Fix beans init failing due to missing directory
+status: in-progress
+type: bug
+priority: high
+created_at: 2026-02-28T01:34:12Z
+updated_at: 2026-02-28T01:34:12Z
+---
+
+When running `sarge proj create` on a repo that doesn't have beans, the project-local beans init fails because the `.co/.beans` directory doesn't exist yet. The `beans.Init()` function sets `cmd.Dir = beansDir` but never creates the directory first, causing a 'chdir: no such file or directory' error.

--- a/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
+++ b/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
@@ -5,7 +5,19 @@ status: in-progress
 type: bug
 priority: high
 created_at: 2026-02-28T01:34:12Z
-updated_at: 2026-02-28T01:34:12Z
+updated_at: 2026-02-28T01:36:12Z
 ---
 
 When running `sarge proj create` on a repo that doesn't have beans, the project-local beans init fails because the `.co/.beans` directory doesn't exist yet. The `beans.Init()` function sets `cmd.Dir = beansDir` but never creates the directory first, causing a 'chdir: no such file or directory' error.
+
+## Summary of Changes
+
+Added `os.MkdirAll(beansDir, 0o755)` call in `beans.Init()` (internal/beans/cli.go) to ensure the target directory exists before running the `beans init` CLI command. This fixes the 'chdir: no such file or directory' error when creating projects with project-local beans.
+
+## Additional Issue
+
+`beansCommand()` in `internal/beans/cli.go` invokes `beans` directly via `exec.CommandContext(ctx, "beans", ...)` rather than through `mise exec -- beans`. During `proj create`, beans is installed by mise, but the Go process won't find it unless it's already on the global PATH. The `Init()` function should use `mise exec` to invoke beans through the mise-managed environment.
+
+## Todo
+- [x] Create the beans directory before running beans init
+- [ ] Make `beans.Init()` use mise exec to invoke the mise-installed beans binary

--- a/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
+++ b/.beans/main-2ods--fix-beans-init-failing-due-to-missing-directory.md
@@ -1,11 +1,11 @@
 ---
 # main-2ods
 title: Fix beans init failing due to missing directory
-status: in-progress
+status: completed
 type: bug
 priority: high
 created_at: 2026-02-28T01:34:12Z
-updated_at: 2026-02-28T01:36:12Z
+updated_at: 2026-02-28T01:37:14Z
 ---
 
 When running `sarge proj create` on a repo that doesn't have beans, the project-local beans init fails because the `.co/.beans` directory doesn't exist yet. The `beans.Init()` function sets `cmd.Dir = beansDir` but never creates the directory first, causing a 'chdir: no such file or directory' error.
@@ -20,4 +20,4 @@ Added `os.MkdirAll(beansDir, 0o755)` call in `beans.Init()` (internal/beans/cli.
 
 ## Todo
 - [x] Create the beans directory before running beans init
-- [ ] Make `beans.Init()` use mise exec to invoke the mise-installed beans binary
+- [x] Make `beans.Init()` use mise exec to invoke the mise-installed beans binary

--- a/internal/beans/cli.go
+++ b/internal/beans/cli.go
@@ -247,14 +247,24 @@ func (c *cliImpl) AddDependency(ctx context.Context, beanID, dependsOnID string)
 }
 
 // Init initializes beans in the specified directory.
-func Init(ctx context.Context, beansDir, prefix string) error {
+// Init initializes a new beans repository in beansDir.
+// projectRoot is the project root where mise is configured, used to invoke
+// the mise-installed beans binary via "mise exec -- beans init".
+func Init(ctx context.Context, beansDir, prefix, projectRoot string) error {
 	// Ensure the target directory exists before running beans init
-	if err := os.MkdirAll(beansDir, 0o755); err != nil {
+	if err := os.MkdirAll(beansDir, 0o750); err != nil {
 		return fmt.Errorf("failed to create beans directory %s: %w", beansDir, err)
 	}
-	cmd := beansCommand(ctx, "", "init", "--prefix", prefix)
-	// beans init creates .beans/ in the current working directory
+
+	// Use "mise exec" to invoke beans, since beans was just installed by mise
+	// and may not be on the global PATH yet.
+	cmd := exec.CommandContext(ctx, "mise", "exec", "--", "beans", "init", "--prefix", prefix)
 	cmd.Dir = beansDir
+
+	// Set MISE_PROJECT_DIR so mise loads the project root's .mise.toml
+	// (since cmd.Dir is the beans subdirectory, not the project root)
+	cmd.Env = append(os.Environ(), "MISE_PROJECT_DIR="+projectRoot)
+
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("beans init failed: %w\n%s", err, output)
 	}

--- a/internal/beans/cli.go
+++ b/internal/beans/cli.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/sargehq/sarge/internal/logging"
 )
@@ -248,6 +249,7 @@ func (c *cliImpl) AddDependency(ctx context.Context, beanID, dependsOnID string)
 
 // Init initializes beans in the specified directory.
 // Init initializes a new beans repository in beansDir.
+// prefix is the bean ID prefix (e.g. "a" becomes "a-" in .beans.yml).
 // projectRoot is the project root where mise is configured, used to invoke
 // the mise-installed beans binary via "mise exec -- beans init".
 func Init(ctx context.Context, beansDir, prefix, projectRoot string) error {
@@ -258,7 +260,7 @@ func Init(ctx context.Context, beansDir, prefix, projectRoot string) error {
 
 	// Use "mise exec" to invoke beans, since beans was just installed by mise
 	// and may not be on the global PATH yet.
-	cmd := exec.CommandContext(ctx, "mise", "exec", "--", "beans", "init", "--prefix", prefix)
+	cmd := exec.CommandContext(ctx, "mise", "exec", "--", "beans", "init")
 	cmd.Dir = beansDir
 
 	// Set MISE_PROJECT_DIR so mise loads the project root's .mise.toml
@@ -268,6 +270,39 @@ func Init(ctx context.Context, beansDir, prefix, projectRoot string) error {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("beans init failed: %w\n%s", err, output)
 	}
+
+	// Update the prefix in .beans.yml (beans init auto-derives it from the
+	// directory name, but we want it based on the repo name).
+	configPath := filepath.Join(beansDir, ".beans.yml")
+	configData, err := os.ReadFile(configPath) // #nosec G304 -- path is constructed internally
+	if err != nil {
+		return fmt.Errorf("failed to read beans config: %w", err)
+	}
+
+	// Replace the auto-derived prefix with our desired prefix
+	updated := strings.Replace(
+		string(configData),
+		"prefix: .beans-",
+		"prefix: "+prefix+"-",
+		1,
+	)
+	if updated == string(configData) {
+		// Try without the dot prefix (directory name may vary)
+		// Fall back to a more general replacement
+		lines := strings.Split(string(configData), "\n")
+		for i, line := range lines {
+			if strings.HasPrefix(strings.TrimSpace(line), "prefix:") {
+				lines[i] = "    prefix: " + prefix + "-"
+				break
+			}
+		}
+		updated = strings.Join(lines, "\n")
+	}
+
+	if err := os.WriteFile(configPath, []byte(updated), 0o600); err != nil {
+		return fmt.Errorf("failed to update beans config: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/beans/cli.go
+++ b/internal/beans/cli.go
@@ -248,6 +248,10 @@ func (c *cliImpl) AddDependency(ctx context.Context, beanID, dependsOnID string)
 
 // Init initializes beans in the specified directory.
 func Init(ctx context.Context, beansDir, prefix string) error {
+	// Ensure the target directory exists before running beans init
+	if err := os.MkdirAll(beansDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create beans directory %s: %w", beansDir, err)
+	}
 	cmd := beansCommand(ctx, "", "init", "--prefix", prefix)
 	// beans init creates .beans/ in the current working directory
 	cmd.Dir = beansDir

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -309,7 +309,7 @@ func setupBeans(ctx context.Context, source, projectRoot, mainPath string) (bean
 		prefix := repoNameFromSource(source)
 
 		// Initialize beans in project directory
-		if err := beans.Init(ctx, projectBeansPath, prefix); err != nil {
+		if err := beans.Init(ctx, projectBeansPath, prefix, projectRoot); err != nil {
 			return "", fmt.Errorf("failed to initialize beans: %w", err)
 		}
 	}


### PR DESCRIPTION
## Problem

`sarge proj create` fails when initializing project-local beans (`.co/.beans`) with:

```
Error: failed to create project: failed to initialize beans: beans init failed: chdir /home/matthew/a-proj/.co/.beans: no such file or directory
```

## Root Causes

**1. Missing directory:** `beans.Init()` set `cmd.Dir` to `.co/.beans` but never created the directory first, causing the `chdir` error.

**2. `beans` not invoked through mise:** `beans.Init()` called `exec.CommandContext(ctx, "beans", ...)` directly, but during `proj create`, beans is installed by mise and may not be on the global PATH. The code should use `mise exec -- beans init` to find the mise-installed binary.

## Fix

- Added `os.MkdirAll()` to create the beans directory before running `beans init`
- Changed `Init()` to invoke `mise exec -- beans init` with `MISE_PROJECT_DIR` set to the project root, so mise loads the correct `.mise.toml` and finds the installed beans binary
- Added `projectRoot` parameter to `beans.Init()` signature and updated the call site

bean: main-2ods