### PR TITLE
feat: Pi sessions embedded in work tabs

### DIFF
--- a/.beans/main-ow5d--pi-sessions-embedded-in-work-tabs.md
+++ b/.beans/main-ow5d--pi-sessions-embedded-in-work-tabs.md
@@ -1,0 +1,56 @@
+---
+# main-ow5d
+title: Pi sessions embedded in work tabs
+status: in-progress
+type: feature
+priority: high
+created_at: 2026-03-11T18:51:06Z
+updated_at: 2026-03-11T18:53:09Z
+---
+
+## Overview
+
+Rework the TUI so that each work tab embeds a pi PTY session alongside the work details panel. Plan sessions also get their own work tab. A default/global pi session tab is always present at startup.
+
+## Design
+
+### Tab Types
+1. **Default tab** — Always-present global pi session ("Main"), spawned at TUI startup. For managing the overall session/running commands in the main repo.
+2. **Work tabs** — One per active work. Shows work details + embedded pi session(s). The pi session panel can be maximized.
+3. **Plan tabs** — Created on `p` key for a bean. Shows a planning pi session as its own tab in the work tabs bar.
+
+### Within a Work Tab
+- Work details panel (tasks, beans, orchestrator health) shown as a panel
+- Pi session(s) shown as a split within the work: agent, console, plan sub-sessions
+- A way to maximize the session view (toggle between split and full)
+
+### Session Lifecycle
+- **Work sessions**: pi session spawns automatically when needed (work creation/run)
+- **Plan sessions**: spawned on `p` key press, appears as new tab
+- **Default session**: spawned at TUI startup, always available
+
+## Implementation Plan
+
+### Phase 1: Tab Model
+- [ ] Create WorkTab struct with types: Default, Work, Plan
+- [ ] Each tab holds references to its pi session(s) and work data
+- [ ] Update WorkTabsBar to render new tab types (Main, work tabs, plan tabs)
+
+### Phase 2: Default Pi Session
+- [ ] Spawn a default pi session at TUI startup (main repo dir, no prompt)
+- [ ] Always show "Main" tab as first tab
+- [ ] When Main tab is selected, show full-screen session panel
+
+### Phase 3: Session Embedding in Work Tabs
+- [ ] When a work tab is selected, show split: work details (top) + session (bottom)
+- [ ] Sub-sessions within a work: agent, console, plan (ctrl+1/2/3 to switch)
+- [ ] z key to maximize/minimize session panel (toggle between split and full)
+
+### Phase 4: Plan Sessions as Tabs
+- [ ] When p is pressed on a bean, create a new plan tab in the work tabs bar
+- [ ] Remove the ViewSessionViewer overlay in favor of tab-based viewing
+
+### Phase 5: Wiring & Polish
+- [ ] Wire automatic session spawning for work sessions
+- [ ] Update key bindings and mouse handling
+- [ ] Update help text

--- a/.beans/main-ow5d--pi-sessions-embedded-in-work-tabs.md
+++ b/.beans/main-ow5d--pi-sessions-embedded-in-work-tabs.md
@@ -1,11 +1,11 @@
 ---
 # main-ow5d
 title: Pi sessions embedded in work tabs
-status: in-progress
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-11T18:51:06Z
-updated_at: 2026-03-11T18:53:09Z
+updated_at: 2026-03-11T19:00:37Z
 ---
 
 ## Overview
@@ -32,25 +32,36 @@ Rework the TUI so that each work tab embeds a pi PTY session alongside the work 
 ## Implementation Plan
 
 ### Phase 1: Tab Model
-- [ ] Create WorkTab struct with types: Default, Work, Plan
-- [ ] Each tab holds references to its pi session(s) and work data
-- [ ] Update WorkTabsBar to render new tab types (Main, work tabs, plan tabs)
+- [x] Create WorkTab struct with types: Default, Work, Plan
+- [x] Each tab holds references to its pi session(s) and work data
+- [x] Update WorkTabsBar to render new tab types (Main, work tabs, plan tabs)
 
 ### Phase 2: Default Pi Session
-- [ ] Spawn a default pi session at TUI startup (main repo dir, no prompt)
-- [ ] Always show "Main" tab as first tab
-- [ ] When Main tab is selected, show full-screen session panel
+- [x] Spawn a default pi session at TUI startup (main repo dir, no prompt)
+- [x] Always show "Main" tab as first tab
+- [x] When Main tab is selected, show full-screen session panel
 
 ### Phase 3: Session Embedding in Work Tabs
-- [ ] When a work tab is selected, show split: work details (top) + session (bottom)
-- [ ] Sub-sessions within a work: agent, console, plan (ctrl+1/2/3 to switch)
-- [ ] z key to maximize/minimize session panel (toggle between split and full)
+- [x] When a work tab is selected, show split: work details (top) + session (bottom)
+- [x] Sub-sessions within a work: agent, console, plan (ctrl+1/2/3 to switch)
+- [x] z key to maximize/minimize session panel (toggle between split and full)
 
 ### Phase 4: Plan Sessions as Tabs
-- [ ] When p is pressed on a bean, create a new plan tab in the work tabs bar
-- [ ] Remove the ViewSessionViewer overlay in favor of tab-based viewing
+- [x] When p is pressed on a bean, create a new plan tab in the work tabs bar
+- [x] Remove the ViewSessionViewer overlay in favor of tab-based viewing
 
 ### Phase 5: Wiring & Polish
-- [ ] Wire automatic session spawning for work sessions
-- [ ] Update key bindings and mouse handling
-- [ ] Update help text
+- [x] Wire automatic session spawning for work sessions
+- [x] Update key bindings and mouse handling
+- [x] Update help text
+
+## Summary of Changes
+
+### New Files
+- `internal/tui/tui_work_tab.go` — WorkTab model with Default/Work/Plan types, sub-session tracking, and session maximize state
+
+### Modified Files
+- `internal/tui/tui_panel_work_tabs.go` — Dual rendering: new tab-based rendering with distinct colors per type (teal for Main, purple for Plan, gray/orange for Work) + legacy fallback
+- `internal/tui/tui_plan.go` — Tab lifecycle management (syncTabs, activateTab), default session spawning, session input forwarding, z/ctrl+1-3/0 key bindings, Tab cycling through session panel
+- `internal/tui/tui_plan_render.go` — New renderSessionFullscreen() and renderWorkTabContent() for tab-based layouts
+- `internal/tui/tui_plan_work.go` — spawnDefaultSession() for the always-present Main pi session

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,7 +15,7 @@ var configCmd = &cobra.Command{
 	Long: `Reconfigure the current project interactively.
 
 Re-runs tool selection, regenerates .mise.toml, runs mise install,
-and updates config.toml with new settings.`,
+and updates config2.toml with new settings.`,
 	RunE: runConfig,
 }
 
@@ -44,9 +44,9 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to run mise install: %w", err)
 	}
 
-	// 5. Merge new config sections into config.toml
+	// 5. Merge new config sections into config2.toml
 	configPath := filepath.Join(proj.Root, project.ConfigDir, project.ConfigFile)
-	fmt.Println("Updating config.toml...")
+	fmt.Println("Updating config2.toml...")
 	added, err := project.UpdateConfig(configPath, proj.Config)
 	if err != nil {
 		return fmt.Errorf("failed to update config: %w", err)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -20,7 +20,7 @@ var doctorCmd = &cobra.Command{
 	Long: `Run project health checks and apply fixes.
 
 Checks include:
-  - Config update: ensures config.toml has all available sections
+  - Config update: ensures config2.toml has all available sections
   - Mise beans version: ensures the mise config has the correct beans version
   - Beans extension (pi): ensures the beans-prime extension is installed
   - Sarge extension (pi): ensures the sarge-complete extension is installed

--- a/cmd/linear.go
+++ b/cmd/linear.go
@@ -42,7 +42,7 @@ Examples:
 Authentication:
   The Linear API key can be provided via (in order of precedence):
   1. --api-key flag
-  2. [linear] api_key in .co/config.toml
+  2. [linear] api_key in .co/config2.toml
 
 Environment Variables:
   BEANS_PATH         Beans directory (default: auto-detect)
@@ -68,7 +68,7 @@ func init() {
 	linearCmd.AddCommand(linearImportCmd)
 
 	// Import command flags
-	linearImportCmd.Flags().StringVar(&linearAPIKey, "api-key", "", "Linear API key (or set [linear] api_key in config.toml)")
+	linearImportCmd.Flags().StringVar(&linearAPIKey, "api-key", "", "Linear API key (or set [linear] api_key in config2.toml)")
 	linearImportCmd.Flags().StringVar(&linearBeansDir, "beans-dir", "", "Beans directory (default: auto-detect)")
 	linearImportCmd.Flags().BoolVar(&linearDryRun, "dry-run", false, "Preview import without creating beans")
 	linearImportCmd.Flags().BoolVar(&linearUpdateExist, "update", false, "Update existing beans if already imported")
@@ -91,7 +91,7 @@ func runLinearImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if apiKey == "" {
-		return fmt.Errorf("linear API key is required (set via --api-key flag or [linear] api_key in config.toml)")
+		return fmt.Errorf("linear API key is required (set via --api-key flag or [linear] api_key in config2.toml)")
 	}
 
 	// Get beans directory

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -16,7 +16,7 @@ import (
 //go:embed templates/config.tmpl
 var configTemplateText string
 
-// Config represents the project configuration stored in .co/config.toml.
+// Config represents the project configuration stored in .co/config2.toml.
 type Config struct {
 	Project     ProjectConfig     `toml:"project"`
 	Repo        RepoConfig        `toml:"repo"`

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -20,7 +20,7 @@ const (
 	// ConfigDir is the directory name for project configuration.
 	ConfigDir = ".co"
 	// ConfigFile is the name of the project config file.
-	ConfigFile = "config.toml"
+	ConfigFile = "config2.toml"
 	// TrackingDB is the name of the tracking database file.
 	TrackingDB = "tracking.db"
 	// MainDir is the directory name for the main repository.

--- a/internal/ptysession/session.go
+++ b/internal/ptysession/session.go
@@ -77,6 +77,7 @@ type Session struct {
 	ptm *os.File // PTY master
 
 	emu   *vt.Emulator
+	emuMu sync.Mutex // Protects all emu access (Write, Render, Resize)
 	state atomic.Int32
 
 	mu       sync.Mutex
@@ -202,15 +203,19 @@ func (s *Session) Resize(width, height int) {
 			Cols: clampUint16(width),
 		})
 	}
+	s.emuMu.Lock()
 	if s.emu != nil {
 		s.emu.Resize(width, height)
 	}
+	s.emuMu.Unlock()
 }
 
 // Render returns the current terminal screen as a string with ANSI escape codes.
 // Clears the dirty flag.
 func (s *Session) Render() string {
 	s.dirty.Store(false)
+	s.emuMu.Lock()
+	defer s.emuMu.Unlock()
 	if s.emu == nil {
 		return ""
 	}
@@ -250,7 +255,9 @@ func (s *Session) readLoop() {
 		n, err := s.ptm.Read(buf)
 		if n > 0 {
 			// Feed output to the virtual terminal emulator.
+			s.emuMu.Lock()
 			_, _ = s.emu.Write(buf[:n])
+			s.emuMu.Unlock()
 			s.dirty.Store(true)
 
 			// Notify the TUI that new output is available.

--- a/internal/tui/tui_panel_session.go
+++ b/internal/tui/tui_panel_session.go
@@ -40,7 +40,12 @@ func NewSessionPanel() *SessionPanel {
 
 // SetSize updates the panel dimensions and propagates to the PTY session.
 // The full width/height is given to the PTY — no borders or chrome.
+// Only resizes the PTY when dimensions actually change to avoid a
+// resize → redraw → output → render → resize feedback loop.
 func (p *SessionPanel) SetSize(width, height int) {
+	if p.width == width && p.height == height {
+		return
+	}
 	p.width = width
 	p.height = height
 

--- a/internal/tui/tui_panel_work_tabs.go
+++ b/internal/tui/tui_panel_work_tabs.go
@@ -10,6 +10,7 @@ import (
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/progress"
+	"github.com/sargehq/sarge/internal/ptysession"
 )
 
 // WorkState represents the current state of a work for display purposes
@@ -31,7 +32,11 @@ type WorkTabsBar struct {
 	// Dimensions
 	width int
 
-	// Data
+	// Data — new tab model
+	tabs          []*WorkTab
+	ptyManager    *ptysession.Manager // For checking session liveness
+
+	// Legacy data (kept for compatibility during transition)
 	workTiles          []*progress.WorkProgress
 	focusedWorkID      string
 	hoveredTabID       string
@@ -39,6 +44,9 @@ type WorkTabsBar struct {
 
 	// Panel state
 	activePanel Panel // Which panel is currently focused
+
+	// The ID of the currently focused/active tab
+	activeTabID string
 
 	// Spinner for running works
 	spinner spinner.Model
@@ -66,6 +74,16 @@ func (b *WorkTabsBar) SetSize(width int) {
 	b.width = width
 }
 
+// SetTabs sets the tab list
+func (b *WorkTabsBar) SetTabs(tabs []*WorkTab) {
+	b.tabs = tabs
+}
+
+// SetPTYManager sets the PTY manager for session lookups
+func (b *WorkTabsBar) SetPTYManager(mgr *ptysession.Manager) {
+	b.ptyManager = mgr
+}
+
 // SetWorkTiles updates the work tiles data
 func (b *WorkTabsBar) SetWorkTiles(workTiles []*progress.WorkProgress) {
 	b.workTiles = workTiles
@@ -74,6 +92,11 @@ func (b *WorkTabsBar) SetWorkTiles(workTiles []*progress.WorkProgress) {
 // SetFocusedWorkID sets which work is currently focused
 func (b *WorkTabsBar) SetFocusedWorkID(id string) {
 	b.focusedWorkID = id
+}
+
+// SetActiveTabID sets which tab is currently active/focused
+func (b *WorkTabsBar) SetActiveTabID(id string) {
+	b.activeTabID = id
 }
 
 // SetHoveredTabID sets which tab is being hovered
@@ -141,8 +164,202 @@ func (b *WorkTabsBar) getWorkState(work *progress.WorkProgress) WorkState {
 	return WorkStateIdle
 }
 
+// getTabIcon returns the status icon for a tab
+func (b *WorkTabsBar) getTabIcon(tab *WorkTab) string {
+	switch tab.Type {
+	case WorkTabDefault:
+		// Default tab: show session state
+		if tab.HasActiveSession(b.ptyManager) {
+			unstyled := b.spinner
+			unstyled.Style = lipgloss.NewStyle()
+			return unstyled.View()
+		}
+		return "⌂" // Home icon for main tab
+
+	case WorkTabPlan:
+		// Plan tab: show session state
+		if tab.HasActiveSession(b.ptyManager) {
+			unstyled := b.spinner
+			unstyled.Style = lipgloss.NewStyle()
+			return unstyled.View()
+		}
+		return "◇" // Diamond for plan
+
+	case WorkTabWork:
+		// Work tab: use work state
+		if tab.WorkProgress != nil {
+			state := b.getWorkState(tab.WorkProgress)
+			switch state {
+			case WorkStateMerged:
+				return "✓"
+			case WorkStateCompleted:
+				return "✓"
+			case WorkStateRunning:
+				unstyled := b.spinner
+				unstyled.Style = lipgloss.NewStyle()
+				return unstyled.View()
+			case WorkStateFailed:
+				return "✗"
+			case WorkStateDead:
+				return "☠"
+			default:
+				return "○"
+			}
+		}
+		return "○"
+	}
+	return "?"
+}
+
 // Render renders the tab bar with styled tabs
 func (b *WorkTabsBar) Render() string {
+	// If we have the new tab model, use it
+	if len(b.tabs) > 0 {
+		return b.renderTabs()
+	}
+	// Fall back to legacy rendering
+	return b.renderLegacy()
+}
+
+// renderTabs renders using the new WorkTab model
+func (b *WorkTabsBar) renderTabs() string {
+	// Colors
+	barBg := lipgloss.Color("235")      // Dark background
+	ribbonBg := lipgloss.Color("29")    // Teal for ribbon
+	ribbonFg := lipgloss.Color("15")    // White text
+	inactiveBg := lipgloss.Color("240") // Gray for inactive
+	inactiveFg := lipgloss.Color("255") // Light text
+	activeBg := lipgloss.Color("214")   // Orange for active
+	activeFg := lipgloss.Color("232")   // Dark text
+	planBg := lipgloss.Color("99")      // Purple for plan tabs
+	planFg := lipgloss.Color("255")     // White text
+	defaultBg := lipgloss.Color("29")   // Teal for default tab
+	defaultFg := lipgloss.Color("255")  // White text
+
+	triangle := "\ue0b0" // U+E0B0 - right-pointing solid triangle
+
+	var content string
+
+	// Ribbon
+	ribbonText := " Sarge "
+	if b.activePanel == PanelWorkTabs {
+		ribbonText = "► Sarge ◄"
+	}
+	ribbonStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ribbonFg).
+		Background(ribbonBg)
+	content += ribbonStyle.Render(ribbonText)
+
+	spaceStyle := lipgloss.NewStyle().Background(barBg)
+	content += spaceStyle.Render(" ")
+
+	for i, tab := range b.tabs {
+		isActive := tab.ID == b.activeTabID
+		isHovered := tab.ID == b.hoveredTabID
+
+		// Determine tab colors based on type and state
+		var tabBg, tabFg lipgloss.Color
+		if isActive || isHovered {
+			tabBg = activeBg
+			tabFg = activeFg
+		} else {
+			switch tab.Type {
+			case WorkTabDefault:
+				tabBg = defaultBg
+				tabFg = defaultFg
+			case WorkTabPlan:
+				tabBg = planBg
+				tabFg = planFg
+			default:
+				tabBg = inactiveBg
+				tabFg = inactiveFg
+			}
+		}
+
+		// Build tab content
+		var tabBuilder string
+
+		// Left triangle
+		tabLeftStyle := lipgloss.NewStyle().
+			Foreground(barBg).
+			Background(tabBg)
+		tabBuilder += tabLeftStyle.Render(triangle)
+
+		// Icon
+		icon := b.getTabIcon(tab)
+
+		// Label
+		name := tab.Label
+		name = ansi.Truncate(name, 20, "…")
+
+		// Sub-session indicator for work tabs
+		subIndicator := ""
+		if tab.Type == WorkTabWork {
+			switch tab.ActiveSubSession {
+			case SubSessionAgent:
+				// No indicator — agent is default
+			case SubSessionConsole:
+				subIndicator = " [sh]"
+			case SubSessionPlan:
+				subIndicator = " [pl]"
+			}
+		}
+
+		// Zoom indicator
+		zoomIndicator := ""
+		if tab.SessionMaximized {
+			zoomIndicator = " ◻"
+		}
+
+		tabContent := fmt.Sprintf(" %s %s%s%s", icon, name, subIndicator, zoomIndicator)
+		tabStyle := lipgloss.NewStyle().
+			Foreground(tabFg).
+			Background(tabBg)
+		tabBuilder += tabStyle.Render(tabContent)
+
+		// Warning badges for work tabs
+		if tab.Type == WorkTabWork && tab.WorkProgress != nil {
+			wp := tab.WorkProgress
+			if wp.FeedbackCount > 0 || wp.UnassignedBeanCount > 0 {
+				badgeStyle := lipgloss.NewStyle().
+					Foreground(lipgloss.Color("214")).
+					Background(tabBg)
+				tabBuilder += badgeStyle.Render(" \uf071")
+			}
+			if wp.HasUnseenPRChanges {
+				badgeStyle := lipgloss.NewStyle().
+					Foreground(lipgloss.Color("81")).
+					Background(tabBg)
+				tabBuilder += badgeStyle.Render(" ●")
+			}
+		}
+
+		// Trailing space
+		tabBuilder += tabStyle.Render(" ")
+
+		// Right chevron
+		tabRightStyle := lipgloss.NewStyle().
+			Foreground(tabBg).
+			Background(barBg)
+		tabBuilder += tabRightStyle.Render(triangle)
+
+		content += zone.Mark(b.zonePrefix+tab.ID, tabBuilder)
+
+		if i < len(b.tabs)-1 {
+			content += spaceStyle.Render(" ")
+		}
+	}
+
+	barStyle := lipgloss.NewStyle().
+		Background(barBg).
+		Width(b.width)
+
+	return barStyle.Render(content)
+}
+
+// renderLegacy renders using the old WorkProgress-based model (backward compat)
+func (b *WorkTabsBar) renderLegacy() string {
 	// Colors
 	barBg := lipgloss.Color("235")      // Dark background
 	ribbonBg := lipgloss.Color("29")    // Teal for ribbon
@@ -281,6 +498,13 @@ func (b *WorkTabsBar) Render() string {
 
 // DetectHoveredTab returns the work ID of the tab under the mouse using bubblezone
 func (b *WorkTabsBar) DetectHoveredTab(msg tea.MouseMsg) string {
+	// Check new tabs first
+	for _, tab := range b.tabs {
+		if zone.Get(b.zonePrefix + tab.ID).InBounds(msg) {
+			return tab.ID
+		}
+	}
+	// Fall back to legacy work tiles
 	for _, work := range b.workTiles {
 		if work == nil {
 			continue
@@ -292,7 +516,7 @@ func (b *WorkTabsBar) DetectHoveredTab(msg tea.MouseMsg) string {
 	return ""
 }
 
-// HandleClick handles a mouse click and returns the clicked work ID (if any)
+// HandleClick handles a mouse click and returns the clicked tab ID (if any)
 func (b *WorkTabsBar) HandleClick(msg tea.MouseMsg) string {
 	return b.DetectHoveredTab(msg)
 }

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -271,6 +271,25 @@ func (m *planModel) InModal() bool {
 	return m.viewMode != ViewNormal
 }
 
+// IsShowingSession returns true if the view is currently dominated by a PTY session.
+// Used by the root model to skip zone.Scan which corrupts raw terminal output.
+func (m *planModel) IsShowingSession() bool {
+	if m.viewMode != ViewNormal {
+		return false
+	}
+	activeTab := m.getActiveTab()
+	if activeTab == nil {
+		return false
+	}
+	switch activeTab.Type {
+	case WorkTabDefault, WorkTabPlan:
+		return true
+	case WorkTabWork:
+		return activeTab.SessionMaximized
+	}
+	return false
+}
+
 // Init implements tea.Model
 func (m *planModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{
@@ -334,8 +353,9 @@ func (m *planModel) waitForTrackingWatcherEvent() tea.Cmd {
 func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case ptyOutputMsg:
-		// PTY session has new output — just trigger a re-render.
-		// The session panel will call session.Render() in its View().
+		// PTY session has new output — only meaningful if it's the active session.
+		// Bubbletea always calls View() after Update(), so we can't skip the render,
+		// but we avoid doing any extra work for non-active sessions.
 		return m, nil
 
 	case defaultSessionSpawnedMsg:

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -89,6 +89,10 @@ type planModel struct {
 	workDetailsFocusLeft   bool            // Whether left panel has focus in work details (true=left, false=right)
 	addChildToWorkID       string          // Work ID to add newly created child bean to (for add-child-and-run flow)
 
+	// Tab model
+	tabs        []*WorkTab // All tabs: [Main, work1, work2, ..., plan1, plan2, ...]
+	activeTabID string     // ID of the currently active/focused tab
+
 	// Multi-select state
 	selectedBeans map[string]bool // beanID -> is selected
 
@@ -206,6 +210,11 @@ func newPlanModel(ctx context.Context, proj *project.Project) *planModel {
 	m.bridgeClient = bridge.NewBridge()
 	m.ptyManager = ptysession.NewManager()
 
+	// Initialize tab model with the default "Main" tab
+	defaultTab := NewDefaultTab()
+	m.tabs = []*WorkTab{defaultTab}
+	m.activeTabID = defaultTab.ID
+
 	// Wire PTY manager and bridge into the WorkService's OrchestratorManager.
 	// PTY sessions are used for interactive display (plan/agent/console).
 	// Bridge sessions are used by the sequencer for headless task execution.
@@ -268,6 +277,7 @@ func (m *planModel) Init() tea.Cmd {
 		m.workTabsBar.GetSpinner().Tick, // Tick the tabs bar spinner
 		m.refreshData(),
 		m.loadWorkTiles(), // Load work tiles for the tabs bar
+		m.spawnDefaultSession(), // Spawn the default "Main" pi session
 	}
 
 	// Subscribe to watcher events if watcher is available
@@ -325,6 +335,13 @@ func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ptyOutputMsg:
 		// PTY session has new output — just trigger a re-render.
 		// The session panel will call session.Render() in its View().
+		return m, nil
+
+	case defaultSessionSpawnedMsg:
+		if msg.err != nil {
+			m.statusMessage = fmt.Sprintf("Default session failed: %v", msg.err)
+			m.statusIsError = true
+		}
 		return m, nil
 
 	case watcherEventMsg:
@@ -433,37 +450,9 @@ func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Set focus to work tabs panel when clicking on it
 				m.activePanel = PanelWorkTabs
 
-				clickedWorkID := m.workTabsBar.HandleClick(msg)
-				if clickedWorkID != "" {
-					// Focus the clicked work
-					if m.focusedWorkID == clickedWorkID {
-						// Already focused - unfocus
-						m.focusedWorkID = ""
-						m.filters.task = "" // Clear work selection filter
-						m.filters.children = ""
-						m.activePanel = PanelLeft
-						m.statusMessage = "Work deselected"
-						m.statusIsError = false
-						return m, m.refreshData()
-					}
-					// Focus the new work
-					m.focusedWorkID = clickedWorkID
-					m.viewMode = ViewNormal
-					// Focus the work details panel
-					m.activePanel = PanelWorkDetails
-					m.statusMessage = fmt.Sprintf("Focused on work %s", m.focusedWorkID)
-					m.statusIsError = false
-
-					// Clear unseen PR changes flag for this work
-					_ = m.proj.DB.MarkWorkPRSeen(m.ctx, clickedWorkID)
-
-					// Set up the work details panel
-					focusedWork := m.findWorkByID(m.focusedWorkID)
-					m.workDetails.SetFocusedWork(focusedWork)
-					m.workDetails.SetSelectedIndex(0)
-					m.workDetails.SetOrchestratorHealth(checkOrchestratorHealth(m.ctx, m.proj.DB, m.focusedWorkID))
-
-					return m, m.updateWorkSelectionFilter()
+				clickedTabID := m.workTabsBar.HandleClick(msg)
+				if clickedTabID != "" {
+					return m.activateTab(clickedTabID)
 				}
 				return m, nil
 			}
@@ -675,10 +664,16 @@ func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMessage = fmt.Sprintf("Failed: %v", msg.err)
 			m.statusIsError = true
 		} else if msg.ptySessionID != "" {
-			// PTY session — open session viewer
+			// Plan session created — activate it as a tab
 			m.viewPTYSession(msg.ptySessionID)
-			m.viewMode = ViewSessionViewer
+			// Create/activate the plan tab
+			tabID := msg.ptySessionID // "plan-<beanID>"
+			m.activeTabID = tabID
+			m.focusedWorkID = ""
+			m.filters.task = ""
+			m.filters.children = ""
 			m.activePanel = PanelSession
+			m.viewMode = ViewNormal
 			if msg.resumed {
 				m.statusMessage = fmt.Sprintf("Resumed plan session for %s", msg.beanID)
 			} else {
@@ -701,10 +696,13 @@ func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMessage = fmt.Sprintf("Open Agent failed: %v", msg.err)
 			m.statusIsError = true
 		} else if msg.ptySessionID != "" {
-			// PTY session — open session viewer
+			// Agent session opened — wire it into the work tab's session panel
 			m.viewPTYSession(msg.ptySessionID)
-			m.viewMode = ViewSessionViewer
-			m.activePanel = PanelSession
+			// If we're on the work tab for this work, just stay there
+			// The session will render in the embedded panel
+			if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork && activeTab.WorkID == msg.workID {
+				activeTab.ActiveSubSession = SubSessionAgent
+			}
 			m.statusMessage = fmt.Sprintf("Agent session opened for %s", msg.workID)
 			m.statusIsError = false
 			return m, m.refreshData()
@@ -757,6 +755,7 @@ func (m *planModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// If work was destroyed, clear the focused work
 			if msg.action == "Destroy work" {
 				m.focusedWorkID = ""
+				m.activeTabID = "main"
 				m.filters.task = ""
 				m.filters.children = ""
 			}
@@ -1035,9 +1034,52 @@ func scheduleNewBeanExpire(beanID string) tea.Cmd {
 }
 
 func (m *planModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// When the session panel is focused in normal mode (tab-based sessions),
+	// forward input to the PTY — but intercept escape and control keys.
+	if m.activePanel == PanelSession && m.viewMode == ViewNormal {
+		activeTab := m.getActiveTab()
+		if activeTab != nil {
+			// Escape: exit session focus
+			if msg.Type == tea.KeyEsc {
+				if activeTab.Type == WorkTabWork {
+					// Return to work details panel
+					if activeTab.SessionMaximized {
+						activeTab.SessionMaximized = false
+					}
+					m.activePanel = PanelWorkDetails
+				} else {
+					// Main or plan tab: switch to main tab
+					m.activeTabID = "main"
+					m.activePanel = PanelLeft
+					m.focusedWorkID = ""
+					m.filters.task = ""
+					m.filters.children = ""
+				}
+				return m, nil
+			}
+
+			// Forward all other keys to the PTY session
+			session := activeTab.ActiveSession(m.ptyManager)
+			if session != nil && session.State() != ptysession.SessionDead {
+				raw := keyMsgToBytes(msg)
+				if len(raw) > 0 {
+					_ = session.WriteInput(raw)
+				}
+				return m, nil
+			}
+
+			// Session is dead — esc to leave (handled above), otherwise ignore
+			if msg.Type == tea.KeyEsc {
+				m.activePanel = PanelLeft
+				return m, nil
+			}
+		}
+	}
+
 	// Handle escape key globally for deselecting focused work
 	if msg.Type == tea.KeyEsc && m.viewMode == ViewNormal && m.focusedWorkID != "" {
 		m.focusedWorkID = ""
+		m.activeTabID = "main"
 		m.filters.task = "" // Clear work selection filter
 		m.filters.children = ""
 		m.activePanel = PanelLeft // Reset focus to issues panel
@@ -1385,25 +1427,42 @@ func (m *planModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Handle [1-9] keys to select work by index (works from issues panel and work details panel)
-	if key := msg.String(); len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
+	if key := msg.String(); len(key) == 1 && key[0] >= '0' && key[0] <= '9' {
 		digit := int(key[0] - '0')
+		if digit == 0 {
+			// '0' selects the Main tab
+			return m.activateTab("main")
+		}
 		return m.selectWorkByIndex(digit)
 	}
 
 	switch msg.String() {
 	case "tab":
-		// In focused work mode: cycle between work details (left panel only) and issues
-		// Tab does NOT navigate to work tabs bar or the right panel of work details
+		// In focused work mode: cycle between work details, session, and issues
 		if m.focusedWorkID != "" {
+			activeTab := m.getActiveTab()
+			hasSession := activeTab != nil && activeTab.Type == WorkTabWork && activeTab.HasActiveSession(m.ptyManager)
+
 			switch m.activePanel {
 			case PanelWorkDetails, PanelWorkTabs:
-				// Move from work details (or tabs) to issues panel
+				if hasSession && !activeTab.SessionMaximized {
+					// Move from work details to session panel
+					m.activePanel = PanelSession
+					sessionID := activeTab.SessionID()
+					if s := m.ptyManager.Get(sessionID); s != nil {
+						m.viewPTYSession(sessionID)
+					}
+				} else {
+					// No session — move to issues panel
+					m.activePanel = PanelLeft
+				}
+			case PanelSession:
+				// Move from session to issues panel
 				m.activePanel = PanelLeft
 			case PanelLeft:
 				// Move from issues to work details
 				m.activePanel = PanelWorkDetails
-				m.workDetailsFocusLeft = true // Always focus left panel
-				// Reset the cleared flag and restore work selection filter when entering work details
+				m.workDetailsFocusLeft = true
 				if m.workSelectionCleared {
 					m.workSelectionCleared = false
 					return m, m.updateWorkSelectionFilter()
@@ -1555,6 +1614,57 @@ func (m *planModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filters.sortBy = "default"
 		}
 		return m, m.refreshData()
+
+	case "ctrl+1":
+		// Switch to agent sub-session
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			activeTab.SetSubSession(1)
+			sessionID := activeTab.SessionID()
+			if s := m.ptyManager.Get(sessionID); s != nil {
+				m.viewPTYSession(sessionID)
+			}
+		}
+		return m, nil
+
+	case "ctrl+2":
+		// Switch to console sub-session
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			activeTab.SetSubSession(2)
+			sessionID := activeTab.SessionID()
+			if s := m.ptyManager.Get(sessionID); s != nil {
+				m.viewPTYSession(sessionID)
+			}
+		}
+		return m, nil
+
+	case "ctrl+3":
+		// Switch to plan sub-session
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			activeTab.SetSubSession(3)
+			sessionID := activeTab.SessionID()
+			if s := m.ptyManager.Get(sessionID); s != nil {
+				m.viewPTYSession(sessionID)
+			}
+		}
+		return m, nil
+
+	case "z":
+		// Toggle session maximize for the active work tab
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			activeTab.SessionMaximized = !activeTab.SessionMaximized
+			if activeTab.SessionMaximized {
+				m.activePanel = PanelSession
+				// Wire session panel to the tab's active session
+				sessionID := activeTab.SessionID()
+				if s := m.ptyManager.Get(sessionID); s != nil {
+					m.viewPTYSession(sessionID)
+				}
+			} else {
+				m.activePanel = PanelWorkDetails
+			}
+			return m, nil
+		}
+		return m, nil
 
 	case "V":
 		m.beansExpanded = !m.beansExpanded
@@ -1818,6 +1928,215 @@ func (m *planModel) openBridgeSessionPicker() {
 	m.viewMode = ViewBridgeSessionPicker
 }
 
+// syncTabs rebuilds the tabs list from current work tiles and plan sessions.
+// The order is: [Main] [work1] [work2] ... [plan1] [plan2] ...
+func (m *planModel) syncTabs() {
+	// Preserve existing tab state (sub-session selection, maximized, etc.)
+	oldTabs := make(map[string]*WorkTab)
+	for _, tab := range m.tabs {
+		oldTabs[tab.ID] = tab
+	}
+
+	var tabs []*WorkTab
+
+	// 1. Default "Main" tab (always first)
+	if old, ok := oldTabs["main"]; ok {
+		tabs = append(tabs, old)
+	} else {
+		tabs = append(tabs, NewDefaultTab())
+	}
+
+	// 2. Work tabs (from work tiles)
+	for _, wp := range m.workTiles {
+		if wp == nil {
+			continue
+		}
+		workID := wp.Work.ID
+		if old, ok := oldTabs[workID]; ok {
+			// Preserve state, update work progress
+			old.WorkProgress = wp
+			old.Label = wp.Work.Name
+			if old.Label == "" {
+				old.Label = workID
+			}
+			tabs = append(tabs, old)
+		} else {
+			tab := NewWorkTab(workID, wp.Work.Name)
+			tab.WorkProgress = wp
+			tabs = append(tabs, tab)
+		}
+	}
+
+	// 3. Plan tabs (from PTY manager — any "plan-*" sessions)
+	ptySessions := m.ptyManager.List()
+	for sessionID, state := range ptySessions {
+		if state == ptysession.SessionDead {
+			continue
+		}
+		if len(sessionID) > 5 && sessionID[:5] == "plan-" {
+			beanID := sessionID[5:]
+			tabID := sessionID // "plan-<beanID>"
+			// Skip if this plan session is within a work tab (has a corresponding work)
+			isWorkPlan := false
+			for _, wp := range m.workTiles {
+				if wp != nil && wp.Work.ID == beanID {
+					isWorkPlan = true
+					break
+				}
+			}
+			if isWorkPlan {
+				continue
+			}
+			if old, ok := oldTabs[tabID]; ok {
+				tabs = append(tabs, old)
+			} else {
+				tabs = append(tabs, NewPlanTab(beanID, ""))
+			}
+		}
+	}
+
+	m.tabs = tabs
+
+	// Ensure activeTabID is still valid
+	found := false
+	for _, tab := range m.tabs {
+		if tab.ID == m.activeTabID {
+			found = true
+			break
+		}
+	}
+	if !found && len(m.tabs) > 0 {
+		m.activeTabID = m.tabs[0].ID
+	}
+}
+
+// getActiveTab returns the currently active tab, or nil.
+func (m *planModel) getActiveTab() *WorkTab {
+	for _, tab := range m.tabs {
+		if tab.ID == m.activeTabID {
+			return tab
+		}
+	}
+	return nil
+}
+
+// getTabByID returns the tab with the given ID, or nil.
+func (m *planModel) getTabByID(id string) *WorkTab {
+	for _, tab := range m.tabs {
+		if tab.ID == id {
+			return tab
+		}
+	}
+	return nil
+}
+
+// activateTab switches to the tab with the given ID.
+func (m *planModel) activateTab(tabID string) (tea.Model, tea.Cmd) {
+	tab := m.getTabByID(tabID)
+	if tab == nil {
+		// Not in new tab model yet — try legacy work focus
+		return m.activateTabLegacy(tabID)
+	}
+
+	// If clicking the already-active tab, toggle it off (back to Main)
+	if m.activeTabID == tabID && tab.Type != WorkTabDefault {
+		m.activeTabID = "main"
+		m.focusedWorkID = ""
+		m.filters.task = ""
+		m.filters.children = ""
+		m.activePanel = PanelLeft
+		m.statusMessage = "Tab deselected"
+		m.statusIsError = false
+		return m, m.refreshData()
+	}
+
+	m.activeTabID = tabID
+	m.viewMode = ViewNormal
+
+	switch tab.Type {
+	case WorkTabDefault:
+		// Main tab: show session, clear work focus
+		m.focusedWorkID = ""
+		m.filters.task = ""
+		m.filters.children = ""
+		m.activePanel = PanelSession
+		// Wire session panel to the main session
+		m.viewPTYSession("main")
+		m.statusMessage = "Main session"
+		m.statusIsError = false
+		return m, nil
+
+	case WorkTabWork:
+		// Work tab: focus the work (same as before)
+		m.focusedWorkID = tab.WorkID
+		m.activePanel = PanelWorkDetails
+		m.statusMessage = fmt.Sprintf("Focused on work %s", m.focusedWorkID)
+		m.statusIsError = false
+
+		// Clear unseen PR changes flag
+		_ = m.proj.DB.MarkWorkPRSeen(m.ctx, tab.WorkID)
+
+		// Set up work details panel
+		focusedWork := m.findWorkByID(m.focusedWorkID)
+		m.workDetails.SetFocusedWork(focusedWork)
+		m.workDetails.SetSelectedIndex(0)
+		m.workDetails.SetOrchestratorHealth(checkOrchestratorHealth(m.ctx, m.proj.DB, m.focusedWorkID))
+
+		// Wire session panel to the active sub-session
+		sessionID := tab.SessionID()
+		if s := m.ptyManager.Get(sessionID); s != nil {
+			m.viewPTYSession(sessionID)
+		}
+
+		return m, m.updateWorkSelectionFilter()
+
+	case WorkTabPlan:
+		// Plan tab: show the plan session
+		m.focusedWorkID = ""
+		m.filters.task = ""
+		m.filters.children = ""
+		m.activePanel = PanelSession
+		m.viewPTYSession(tab.SessionID())
+		m.statusMessage = fmt.Sprintf("Plan session: %s", tab.BeanID)
+		m.statusIsError = false
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// activateTabLegacy handles tab activation for IDs not in the new tab model (backward compat).
+func (m *planModel) activateTabLegacy(tabID string) (tea.Model, tea.Cmd) {
+	// Try to match as a work ID
+	if m.focusedWorkID == tabID {
+		// Already focused - unfocus
+		m.focusedWorkID = ""
+		m.activeTabID = "main"
+		m.filters.task = ""
+		m.filters.children = ""
+		m.activePanel = PanelLeft
+		m.statusMessage = "Work deselected"
+		m.statusIsError = false
+		return m, m.refreshData()
+	}
+
+	m.focusedWorkID = tabID
+	m.activeTabID = tabID
+	m.viewMode = ViewNormal
+	m.activePanel = PanelWorkDetails
+	m.statusMessage = fmt.Sprintf("Focused on work %s", m.focusedWorkID)
+	m.statusIsError = false
+
+	_ = m.proj.DB.MarkWorkPRSeen(m.ctx, tabID)
+
+	focusedWork := m.findWorkByID(m.focusedWorkID)
+	m.workDetails.SetFocusedWork(focusedWork)
+	m.workDetails.SetSelectedIndex(0)
+	m.workDetails.SetOrchestratorHealth(checkOrchestratorHealth(m.ctx, m.proj.DB, m.focusedWorkID))
+
+	return m, m.updateWorkSelectionFilter()
+}
+
 // syncPanels synchronizes data from planModel to the panel components
 func (m *planModel) syncPanels() {
 	// Calculate column widths
@@ -1873,10 +2192,14 @@ func (m *planModel) syncPanels() {
 	}
 	m.detailsPanel.SetData(focusedBean, hasActiveSession, childBeanMap)
 
-	// Sync work tabs bar
+	// Sync tabs and work tabs bar
+	m.syncTabs()
 	m.workTabsBar.SetSize(m.width)
 	m.workTabsBar.SetActivePanel(m.activePanel)
-	// Note: Work tiles are set asynchronously when work tiles are loaded
+	m.workTabsBar.SetTabs(m.tabs)
+	m.workTabsBar.SetPTYManager(m.ptyManager)
+	m.workTabsBar.SetActiveTabID(m.activeTabID)
+	// Legacy compatibility
 	m.workTabsBar.SetFocusedWorkID(m.focusedWorkID)
 	// Note: Orchestrator health is set asynchronously when work tiles are loaded
 
@@ -1964,7 +2287,37 @@ func (m *planModel) View() string {
 	originalHeight := m.height
 	m.height = m.height - tabsBarHeight
 	m.syncPanels() // Sync all panels including status bar before rendering
-	content := m.renderTwoColumnLayout()
+
+	// Determine content based on active tab
+	activeTab := m.getActiveTab()
+	var content string
+
+	if activeTab != nil && m.viewMode == ViewNormal {
+		switch activeTab.Type {
+		case WorkTabDefault:
+			// Main tab: full-screen session panel
+			content = m.renderSessionFullscreen()
+
+		case WorkTabPlan:
+			// Plan tab: full-screen session panel
+			content = m.renderSessionFullscreen()
+
+		case WorkTabWork:
+			if activeTab.SessionMaximized {
+				// Maximized session: full-screen session panel
+				content = m.renderSessionFullscreen()
+			} else {
+				// Normal work tab: work details + session split, with issues below
+				content = m.renderWorkTabContent(activeTab)
+			}
+
+		default:
+			content = m.renderTwoColumnLayout()
+		}
+	} else {
+		content = m.renderTwoColumnLayout()
+	}
+
 	m.height = originalHeight
 
 	// Render status bar AFTER syncPanels to ensure status message is set
@@ -2100,6 +2453,7 @@ func (m *planModel) doSelectWorkAtIndex(index int) (tea.Model, tea.Cmd) {
 
 	// Select the work
 	m.focusedWorkID = work.Work.ID
+	m.activeTabID = work.Work.ID // Sync tab selection
 	m.viewMode = ViewNormal
 	// If we're already on work tabs, stay there, otherwise go to work details
 	if m.activePanel != PanelWorkTabs {

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -1427,12 +1428,14 @@ func (m *planModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Handle [1-9] keys to select work by index (works from issues panel and work details panel)
-	if key := msg.String(); len(key) == 1 && key[0] >= '0' && key[0] <= '9' {
+	if key := msg.String(); len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
 		digit := int(key[0] - '0')
-		if digit == 0 {
-			// '0' selects the Main tab
-			return m.activateTab("main")
+		// 1-9 maps to tab positions: 1=first tab (Main), 2=second tab, etc.
+		tabIndex := digit - 1
+		if tabIndex < len(m.tabs) {
+			return m.activateTab(m.tabs[tabIndex].ID)
 		}
+		// Fall back to legacy work selection if tabs not yet populated
 		return m.selectWorkByIndex(digit)
 	}
 
@@ -1883,12 +1886,32 @@ func (m *planModel) viewPTYSession(sessionID string) {
 	m.sessionPanel.SetSession(session, sessionType)
 
 	// Set up the output callback to wake the Bubbletea event loop.
-	// We capture the program reference via a closure.
+	// We throttle notifications to avoid overwhelming bubbletea with render
+	// cycles when the PTY produces rapid output (e.g., pi startup).
+	var lastNotify atomic.Int64
+	var pendingTimer atomic.Int32 // 1 = timer scheduled
 	session.SetOnOutput(func() {
-		// Send a ptyOutputMsg to trigger a re-render.
-		// This is safe to call from any goroutine.
-		if m.teaProgram != nil {
-			m.teaProgram.Send(ptyOutputMsg{sessionID: sessionID})
+		if m.teaProgram == nil {
+			return
+		}
+		now := time.Now().UnixMilli()
+		prev := lastNotify.Load()
+		// Throttle to at most one notification every 16ms (~60fps)
+		if now-prev >= 16 {
+			if lastNotify.CompareAndSwap(prev, now) {
+				pendingTimer.Store(0)
+				m.teaProgram.Send(ptyOutputMsg{sessionID: sessionID})
+			}
+		} else if pendingTimer.CompareAndSwap(0, 1) {
+			// Schedule a trailing notification to catch final output
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				pendingTimer.Store(0)
+				lastNotify.Store(time.Now().UnixMilli())
+				if m.teaProgram != nil {
+					m.teaProgram.Send(ptyOutputMsg{sessionID: sessionID})
+				}
+			}()
 		}
 	})
 }

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -1774,7 +1774,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			apiKey = m.proj.Config.Linear.APIKey
 		}
 		if apiKey == "" {
-			m.statusMessage = "Linear API key not configured (set [linear] api_key in config.toml)"
+			m.statusMessage = "Linear API key not configured (set [linear] api_key in config2.toml)"
 			m.statusIsError = true
 			return m, nil
 		}

--- a/internal/tui/tui_plan_data.go
+++ b/internal/tui/tui_plan_data.go
@@ -407,7 +407,7 @@ func (m *planModel) importLinearIssue(issueIDsInput string) tea.Cmd {
 			apiKey = m.proj.Config.Linear.APIKey
 		}
 		if apiKey == "" {
-			return linearImportCompleteMsg{err: fmt.Errorf("linear API key not set (set [linear] api_key in config.toml)")}
+			return linearImportCompleteMsg{err: fmt.Errorf("linear API key not set (set [linear] api_key in config2.toml)")}
 		}
 
 		// Create fetcher

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -68,27 +68,20 @@ func (m *planModel) renderFocusedWorkSplitView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, workPanel, planSection)
 }
 
-// renderSessionFullscreen renders a PTY session panel taking up the full content area.
+// renderSessionFullscreen renders a PTY session taking up the full content area.
 // Used for the Main tab, Plan tabs, and maximized work tab sessions.
+// The PTY output is rendered WITHOUT borders/padding — the vt emulator manages
+// its own screen buffer and cursor positioning. Wrapping it in lipgloss panels
+// causes ANSI escape code conflicts and flickering.
 func (m *planModel) renderSessionFullscreen() string {
 	contentHeight := m.height - 1 // -1 for status bar
 
-	// panelStyle border takes 2 lines, title takes 1 line
-	// So the session gets: contentHeight - 2 (border) - 1 (title) inner lines
-	innerHeight := contentHeight - 2 // border top + bottom
-	sessionHeight := innerHeight - 1 // title line
-
-	// Update session panel size — give it the actual space it has
-	// Width: full width minus border (2) minus padding (2)
-	m.sessionPanel.SetSize(m.width-4, sessionHeight)
+	// Give the PTY the full width and height minus 1 line for the title bar
+	sessionHeight := contentHeight - 1
+	m.sessionPanel.SetSize(m.width, sessionHeight)
 	m.sessionPanel.SetFocus(true)
 
-	panelStyle := tuiPanelStyle.Width(m.width - 2).Height(innerHeight)
-	if m.activePanel == PanelSession {
-		panelStyle = panelStyle.BorderForeground(lipgloss.Color("214"))
-	}
-
-	// Show session type indicator
+	// Build a minimal title bar (no border, just a colored line)
 	activeTab := m.getActiveTab()
 	title := "Session"
 	if activeTab != nil {
@@ -110,8 +103,15 @@ func (m *planModel) renderSessionFullscreen() string {
 		}
 	}
 
+	titleStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("236")).
+		Foreground(lipgloss.Color("214")).
+		Bold(true).
+		Width(m.width)
+	titleBar := titleStyle.Render(" " + title)
+
 	sessionContent := m.sessionPanel.Render()
-	return panelStyle.Render(tuiTitleStyle.Render(title) + "\n" + sessionContent)
+	return titleBar + "\n" + sessionContent
 }
 
 // renderWorkTabContent renders a work tab with work details + session split.
@@ -133,19 +133,15 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 	m.workDetails.SetSize(m.width, workPanelHeight)
 	workPanel := m.workDetails.RenderWithPanel(workPanelHeight)
 
-	// Render session panel (bottom)
-	// Wire the session panel to the tab's active session
+	// Render session panel (bottom) — no border, raw PTY output
 	sessionID := tab.SessionID()
 	if s := m.ptyManager.Get(sessionID); s != nil && m.sessionPanel.Session() != s {
 		m.viewPTYSession(sessionID)
 	}
 
-	// sessionHeight is total height for session area
-	// border takes 2, title takes 1, so PTY gets sessionHeight - 3
-	innerSessionHeight := sessionHeight - 2 // border
-	ptyHeight := innerSessionHeight - 1     // title line
-
-	m.sessionPanel.SetSize(m.width-4, ptyHeight) // -4 for border + padding
+	// Session gets full width, height minus 1 for title bar
+	ptyHeight := sessionHeight - 1
+	m.sessionPanel.SetSize(m.width, ptyHeight)
 	m.sessionPanel.SetFocus(m.activePanel == PanelSession)
 
 	// Sub-session indicator
@@ -159,13 +155,16 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 		subLabel = "Plan"
 	}
 
-	sessionPanelStyle := tuiPanelStyle.Width(m.width - 2).Height(innerSessionHeight)
-	if m.activePanel == PanelSession {
-		sessionPanelStyle = sessionPanelStyle.BorderForeground(lipgloss.Color("214"))
-	}
+	// Minimal title bar (no border)
+	titleStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("236")).
+		Foreground(lipgloss.Color("214")).
+		Bold(true).
+		Width(m.width)
+	titleBar := titleStyle.Render(" " + subLabel + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch"))
+
 	sessionContent := m.sessionPanel.Render()
-	titleLine := tuiTitleStyle.Render(subLabel) + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch")
-	sessionPanel := sessionPanelStyle.Render(titleLine + "\n" + sessionContent)
+	sessionPanel := titleBar + "\n" + sessionContent
 
 	return lipgloss.JoinVertical(lipgloss.Left, workPanel, sessionPanel)
 }

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -68,6 +68,97 @@ func (m *planModel) renderFocusedWorkSplitView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, workPanel, planSection)
 }
 
+// renderSessionFullscreen renders a PTY session panel taking up the full content area.
+// Used for the Main tab, Plan tabs, and maximized work tab sessions.
+func (m *planModel) renderSessionFullscreen() string {
+	contentHeight := m.height - 1 // -1 for status bar
+
+	// Update session panel size to full width/height
+	m.sessionPanel.SetSize(m.width, contentHeight)
+	m.sessionPanel.SetFocus(true)
+
+	// Render with a simple border
+	panelStyle := tuiPanelStyle.Width(m.width - 2).Height(contentHeight - 2)
+	if m.activePanel == PanelSession {
+		panelStyle = panelStyle.BorderForeground(lipgloss.Color("214"))
+	}
+
+	// Show session type indicator
+	activeTab := m.getActiveTab()
+	title := "Session"
+	if activeTab != nil {
+		switch activeTab.Type {
+		case WorkTabDefault:
+			title = "Main"
+		case WorkTabPlan:
+			title = "Plan: " + activeTab.BeanID
+		case WorkTabWork:
+			switch activeTab.ActiveSubSession {
+			case SubSessionAgent:
+				title = "Agent: " + activeTab.WorkID
+			case SubSessionConsole:
+				title = "Console: " + activeTab.WorkID
+			case SubSessionPlan:
+				title = "Plan: " + activeTab.WorkID
+			}
+			title += " [z] restore"
+		}
+	}
+
+	sessionContent := m.sessionPanel.Render()
+	return panelStyle.Render(tuiTitleStyle.Render(title) + "\n" + sessionContent)
+}
+
+// renderWorkTabContent renders a work tab with work details + session split.
+// The work details panel is shown on top, with a session panel below it.
+func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
+	// Note: m.height has already been adjusted for tabs bar in View()
+	totalHeight := m.height - 1 // -1 for status bar
+
+	// Split: work details (top ~40%) + session (bottom ~60%)
+	workPanelHeight := m.calculateWorkPanelHeight() + 2 // +2 for border
+	sessionHeight := totalHeight - workPanelHeight
+
+	if sessionHeight < 4 {
+		// Not enough room for session — fall back to normal work split
+		return m.renderFocusedWorkSplitView()
+	}
+
+	// Render work details panel (top)
+	m.workDetails.SetSize(m.width, workPanelHeight)
+	workPanel := m.workDetails.RenderWithPanel(workPanelHeight)
+
+	// Render session panel (bottom)
+	// Wire the session panel to the tab's active session
+	sessionID := tab.SessionID()
+	if s := m.ptyManager.Get(sessionID); s != nil && m.sessionPanel.Session() != s {
+		m.viewPTYSession(sessionID)
+	}
+	m.sessionPanel.SetSize(m.width-2, sessionHeight)
+	m.sessionPanel.SetFocus(m.activePanel == PanelSession)
+
+	// Sub-session indicator
+	subLabel := ""
+	switch tab.ActiveSubSession {
+	case SubSessionAgent:
+		subLabel = "Agent"
+	case SubSessionConsole:
+		subLabel = "Console"
+	case SubSessionPlan:
+		subLabel = "Plan"
+	}
+
+	sessionPanelStyle := tuiPanelStyle.Width(m.width - 2).Height(sessionHeight - 2)
+	if m.activePanel == PanelSession {
+		sessionPanelStyle = sessionPanelStyle.BorderForeground(lipgloss.Color("214"))
+	}
+	sessionContent := m.sessionPanel.Render()
+	titleLine := tuiTitleStyle.Render(subLabel) + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch")
+	sessionPanel := sessionPanelStyle.Render(titleLine + "\n" + sessionContent)
+
+	return lipgloss.JoinVertical(lipgloss.Left, workPanel, sessionPanel)
+}
+
 // renderTwoColumnLayout renders the issues and details panels side-by-side
 func (m *planModel) renderTwoColumnLayout() string {
 	// Check if a work is focused - if so, render split view
@@ -321,14 +412,13 @@ func (m *planModel) renderHelp() string {
 			entry("*", "Show all (clear filters)"),
 		}, "") + "\n" +
 
-		renderSection("Session Viewer", [][]string{
-			entry("j/k ↑/↓", "Scroll output"),
-			entry("g/G", "Jump to top/bottom"),
-			entry("i/enter", "Type a prompt"),
-			entry("ctrl+c", "Abort current run"),
-			entry("ctrl+s", "Steer (interrupt)"),
-			entry("esc", "Exit session viewer"),
-		}, "Available when viewing a bridge session.") + "\n" +
+		renderSection("Sessions & Tabs", [][]string{
+			entry("z", "Maximize/restore session"),
+			entry("ctrl+1/2/3", "Switch agent/console/plan"),
+			entry("Tab", "Cycle panels (details→session→issues)"),
+			entry("esc", "Exit session / deselect work"),
+			entry("1-9", "Select work tab"),
+		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with [p] on a bean.") + "\n" +
 
 		renderSection("Indicators", [][]string{
 			entry("●", "Multi-selected"),

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -110,15 +111,22 @@ func (m *planModel) renderSessionFullscreen() string {
 		Width(m.width)
 	titleBar := titleStyle.Render(" " + title)
 
+	// Render session content RAW — do not pass through lipgloss.
+	// The vt emulator outputs precisely formatted ANSI escape codes;
+	// lipgloss.Render() would rewrite/corrupt them causing flicker.
 	sessionContent := m.sessionPanel.Render()
 
-	// Ensure the session content fills the allocated height.
-	// Without this, when there's no session or minimal output, the view
-	// collapses to a few lines instead of filling the screen.
-	contentStyle := lipgloss.NewStyle().
-		Width(m.width).
-		Height(sessionHeight)
-	return titleBar + "\n" + contentStyle.Render(sessionContent)
+	// Pad with blank lines if session output is shorter than allocated height.
+	lines := strings.Count(sessionContent, "\n") + 1
+	if sessionContent == "" {
+		lines = 0
+	}
+	for lines < sessionHeight {
+		sessionContent += "\n"
+		lines++
+	}
+
+	return titleBar + "\n" + sessionContent
 }
 
 // renderWorkTabContent renders a work tab with work details + session split.
@@ -170,11 +178,17 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 		Width(m.width)
 	titleBar := titleStyle.Render(" " + subLabel + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch"))
 
+	// Render session content RAW — do not pass through lipgloss.
 	sessionContent := m.sessionPanel.Render()
-	contentStyle := lipgloss.NewStyle().
-		Width(m.width).
-		Height(ptyHeight)
-	sessionPanel := titleBar + "\n" + contentStyle.Render(sessionContent)
+	lines := strings.Count(sessionContent, "\n") + 1
+	if sessionContent == "" {
+		lines = 0
+	}
+	for lines < ptyHeight {
+		sessionContent += "\n"
+		lines++
+	}
+	sessionPanel := titleBar + "\n" + sessionContent
 
 	return lipgloss.JoinVertical(lipgloss.Left, workPanel, sessionPanel)
 }

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -73,12 +73,17 @@ func (m *planModel) renderFocusedWorkSplitView() string {
 func (m *planModel) renderSessionFullscreen() string {
 	contentHeight := m.height - 1 // -1 for status bar
 
-	// Update session panel size to full width/height
-	m.sessionPanel.SetSize(m.width, contentHeight)
+	// panelStyle border takes 2 lines, title takes 1 line
+	// So the session gets: contentHeight - 2 (border) - 1 (title) inner lines
+	innerHeight := contentHeight - 2 // border top + bottom
+	sessionHeight := innerHeight - 1 // title line
+
+	// Update session panel size — give it the actual space it has
+	// Width: full width minus border (2) minus padding (2)
+	m.sessionPanel.SetSize(m.width-4, sessionHeight)
 	m.sessionPanel.SetFocus(true)
 
-	// Render with a simple border
-	panelStyle := tuiPanelStyle.Width(m.width - 2).Height(contentHeight - 2)
+	panelStyle := tuiPanelStyle.Width(m.width - 2).Height(innerHeight)
 	if m.activePanel == PanelSession {
 		panelStyle = panelStyle.BorderForeground(lipgloss.Color("214"))
 	}
@@ -134,7 +139,13 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 	if s := m.ptyManager.Get(sessionID); s != nil && m.sessionPanel.Session() != s {
 		m.viewPTYSession(sessionID)
 	}
-	m.sessionPanel.SetSize(m.width-2, sessionHeight)
+
+	// sessionHeight is total height for session area
+	// border takes 2, title takes 1, so PTY gets sessionHeight - 3
+	innerSessionHeight := sessionHeight - 2 // border
+	ptyHeight := innerSessionHeight - 1     // title line
+
+	m.sessionPanel.SetSize(m.width-4, ptyHeight) // -4 for border + padding
 	m.sessionPanel.SetFocus(m.activePanel == PanelSession)
 
 	// Sub-session indicator
@@ -148,7 +159,7 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 		subLabel = "Plan"
 	}
 
-	sessionPanelStyle := tuiPanelStyle.Width(m.width - 2).Height(sessionHeight - 2)
+	sessionPanelStyle := tuiPanelStyle.Width(m.width - 2).Height(innerSessionHeight)
 	if m.activePanel == PanelSession {
 		sessionPanelStyle = sessionPanelStyle.BorderForeground(lipgloss.Color("214"))
 	}

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -111,7 +111,14 @@ func (m *planModel) renderSessionFullscreen() string {
 	titleBar := titleStyle.Render(" " + title)
 
 	sessionContent := m.sessionPanel.Render()
-	return titleBar + "\n" + sessionContent
+
+	// Ensure the session content fills the allocated height.
+	// Without this, when there's no session or minimal output, the view
+	// collapses to a few lines instead of filling the screen.
+	contentStyle := lipgloss.NewStyle().
+		Width(m.width).
+		Height(sessionHeight)
+	return titleBar + "\n" + contentStyle.Render(sessionContent)
 }
 
 // renderWorkTabContent renders a work tab with work details + session split.
@@ -164,7 +171,10 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 	titleBar := titleStyle.Render(" " + subLabel + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch"))
 
 	sessionContent := m.sessionPanel.Render()
-	sessionPanel := titleBar + "\n" + sessionContent
+	contentStyle := lipgloss.NewStyle().
+		Width(m.width).
+		Height(ptyHeight)
+	sessionPanel := titleBar + "\n" + contentStyle.Render(sessionContent)
 
 	return lipgloss.JoinVertical(lipgloss.Left, workPanel, sessionPanel)
 }

--- a/internal/tui/tui_plan_work.go
+++ b/internal/tui/tui_plan_work.go
@@ -23,6 +23,68 @@ func (m *planModel) sessionName() string {
 	return fmt.Sprintf("sarge-%s", m.proj.Config.Project.Name)
 }
 
+// defaultSessionSpawnedMsg indicates the default pi session was spawned (or failed).
+type defaultSessionSpawnedMsg struct {
+	err error
+}
+
+// spawnDefaultSession spawns the always-present "Main" pi session in the main repo dir.
+func (m *planModel) spawnDefaultSession() tea.Cmd {
+	return func() tea.Msg {
+		sessionID := "main"
+
+		// Don't spawn if already alive
+		if existing := m.ptyManager.Get(sessionID); existing != nil && existing.State() != ptysession.SessionDead {
+			return defaultSessionSpawnedMsg{}
+		}
+
+		mainRepoPath := m.proj.MainRepoPath()
+
+		// Build env
+		env := []string{}
+		beansPath := m.proj.BeansPath()
+		if beansPath != "" {
+			env = append(env, "BEANS_PATH="+beansPath)
+		}
+
+		cfg := ptysession.SessionConfig{
+			Args:    []string{"--no-session"},
+			WorkDir: mainRepoPath,
+			Width:   80,
+			Height:  24,
+			Env:     env,
+		}
+
+		// Apply pi config (provider, model, thinking)
+		if m.proj.Config != nil {
+			if m.proj.Config.Pi.Provider != "" {
+				cfg.Args = append(cfg.Args, "--provider", m.proj.Config.Pi.Provider)
+			}
+			if m.proj.Config.Pi.Model != "" {
+				cfg.Args = append(cfg.Args, "--model", m.proj.Config.Pi.Model)
+			}
+			if m.proj.Config.Pi.Thinking != "" {
+				cfg.Args = append(cfg.Args, "--thinking", m.proj.Config.Pi.Thinking)
+			}
+		}
+
+		session, err := m.ptyManager.Spawn(sessionID, cfg)
+		if err != nil {
+			logging.Warn("failed to spawn default pi session", "error", err)
+			return defaultSessionSpawnedMsg{err: err}
+		}
+
+		// Wire up output callback
+		session.SetOnOutput(func() {
+			if m.teaProgram != nil {
+				m.teaProgram.Send(ptyOutputMsg{sessionID: sessionID})
+			}
+		})
+
+		return defaultSessionSpawnedMsg{}
+	}
+}
+
 // spawnPlanSession spawns or resumes a planning session for a specific bean.
 // Creates a PTY session and opens the session viewer.
 func (m *planModel) spawnPlanSession(beanID string) tea.Cmd {

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -152,9 +152,15 @@ func (m rootModel) View() string {
 		return ""
 	}
 
-	// Render plan model content directly and wrap with zone.Scan
 	if m.planModel != nil {
-		return zone.Scan(m.planModel.View())
+		view := m.planModel.View()
+		// Skip zone.Scan when showing a PTY session — zone.Scan processes
+		// the string looking for bubblezone markers and corrupts raw ANSI
+		// terminal output from the vt emulator.
+		if m.planModel.IsShowingSession() {
+			return view
+		}
+		return zone.Scan(view)
 	}
 
 	return ""

--- a/internal/tui/tui_work_tab.go
+++ b/internal/tui/tui_work_tab.go
@@ -1,0 +1,175 @@
+package tui
+
+import (
+	"github.com/sargehq/sarge/internal/progress"
+	"github.com/sargehq/sarge/internal/ptysession"
+)
+
+// WorkTabType represents the type of a work tab.
+type WorkTabType int
+
+const (
+	// WorkTabDefault is the always-present "Main" tab with a global pi session.
+	WorkTabDefault WorkTabType = iota
+	// WorkTabWork is a tab for an active work unit (has work details + sessions).
+	WorkTabWork
+	// WorkTabPlan is a tab for a bean planning session.
+	WorkTabPlan
+)
+
+// WorkTabSubSession identifies which sub-session is active within a work tab.
+type WorkTabSubSession int
+
+const (
+	// SubSessionAgent is the agent/chat pi session.
+	SubSessionAgent WorkTabSubSession = iota
+	// SubSessionConsole is the terminal/console pi session.
+	SubSessionConsole
+	// SubSessionPlan is a planning pi session within a work.
+	SubSessionPlan
+)
+
+// WorkTab represents a single tab in the work tabs bar.
+// It can be a default session, a work unit, or a standalone plan session.
+type WorkTab struct {
+	// ID is the unique identifier for this tab.
+	// For default: "main"
+	// For work: the work ID (e.g., "w-abc")
+	// For plan: "plan-<beanID>"
+	ID string
+
+	// Type determines the tab behavior and rendering.
+	Type WorkTabType
+
+	// Label is the display name shown in the tab bar.
+	Label string
+
+	// --- Work tab fields ---
+
+	// WorkID is set for WorkTabWork tabs.
+	WorkID string
+
+	// WorkProgress holds cached work data (tasks, beans, etc.) for work tabs.
+	WorkProgress *progress.WorkProgress
+
+	// ActiveSubSession is which sub-session is currently shown (work tabs only).
+	ActiveSubSession WorkTabSubSession
+
+	// SessionMaximized is true when the session panel is zoomed to fill the content area.
+	SessionMaximized bool
+
+	// --- Plan tab fields ---
+
+	// BeanID is set for WorkTabPlan tabs (the bean being planned).
+	BeanID string
+
+	// --- Session references ---
+	// These are looked up from the PTY manager by convention:
+	//   default:  session ID "main"
+	//   agent:    session ID "agent-<workID>"
+	//   console:  session ID "console-<workID>"
+	//   plan:     session ID "plan-<beanID>"
+}
+
+// SessionID returns the PTY session ID for the currently active session in this tab.
+func (t *WorkTab) SessionID() string {
+	switch t.Type {
+	case WorkTabDefault:
+		return "main"
+	case WorkTabWork:
+		switch t.ActiveSubSession {
+		case SubSessionAgent:
+			return "agent-" + t.WorkID
+		case SubSessionConsole:
+			return "console-" + t.WorkID
+		case SubSessionPlan:
+			// Plan within a work — uses the root bean ID
+			return "plan-" + t.WorkID
+		}
+		return "agent-" + t.WorkID
+	case WorkTabPlan:
+		return "plan-" + t.BeanID
+	}
+	return ""
+}
+
+// ActiveSession returns the PTY session for the currently active sub-session,
+// or nil if no session is running.
+func (t *WorkTab) ActiveSession(mgr *ptysession.Manager) *ptysession.Session {
+	if mgr == nil {
+		return nil
+	}
+	return mgr.Get(t.SessionID())
+}
+
+// HasActiveSession returns true if the tab has a running PTY session.
+func (t *WorkTab) HasActiveSession(mgr *ptysession.Manager) bool {
+	s := t.ActiveSession(mgr)
+	return s != nil && s.State() != ptysession.SessionDead
+}
+
+// CycleSubSession cycles to the next sub-session within a work tab.
+func (t *WorkTab) CycleSubSession() {
+	if t.Type != WorkTabWork {
+		return
+	}
+	switch t.ActiveSubSession {
+	case SubSessionAgent:
+		t.ActiveSubSession = SubSessionConsole
+	case SubSessionConsole:
+		t.ActiveSubSession = SubSessionPlan
+	case SubSessionPlan:
+		t.ActiveSubSession = SubSessionAgent
+	}
+}
+
+// SetSubSession sets the active sub-session by index (1=agent, 2=console, 3=plan).
+func (t *WorkTab) SetSubSession(index int) {
+	if t.Type != WorkTabWork {
+		return
+	}
+	switch index {
+	case 1:
+		t.ActiveSubSession = SubSessionAgent
+	case 2:
+		t.ActiveSubSession = SubSessionConsole
+	case 3:
+		t.ActiveSubSession = SubSessionPlan
+	}
+}
+
+// NewDefaultTab creates the always-present "Main" tab.
+func NewDefaultTab() *WorkTab {
+	return &WorkTab{
+		ID:    "main",
+		Type:  WorkTabDefault,
+		Label: "Main",
+	}
+}
+
+// NewWorkTab creates a tab for an active work unit.
+func NewWorkTab(workID string, label string) *WorkTab {
+	if label == "" {
+		label = workID
+	}
+	return &WorkTab{
+		ID:               workID,
+		Type:             WorkTabWork,
+		Label:            label,
+		WorkID:           workID,
+		ActiveSubSession: SubSessionAgent,
+	}
+}
+
+// NewPlanTab creates a tab for a standalone bean planning session.
+func NewPlanTab(beanID string, label string) *WorkTab {
+	if label == "" {
+		label = "plan:" + beanID
+	}
+	return &WorkTab{
+		ID:     "plan-" + beanID,
+		Type:   WorkTabPlan,
+		Label:  label,
+		BeanID: beanID,
+	}
+}


### PR DESCRIPTION
## Overview

Rework the TUI so that each work tab embeds a pi PTY session alongside work details. Plan sessions get their own tab. A default "Main" pi session is always present.

## Changes

### New: `WorkTab` model (`tui_work_tab.go`)
- Three tab types: **Default** (Main), **Work**, **Plan**
- Each work tab tracks its active sub-session (agent/console/plan) and maximize state
- `SessionID()` maps tab state → PTY session ID by convention

### Tab bar (`tui_panel_work_tabs.go`)
- Distinct colors per type: teal (Main), purple (Plan), gray/orange (Work)
- Sub-session indicator (`[sh]`/`[pl]`) and zoom indicator (`◻`) in work tabs
- Backward-compatible: falls back to legacy rendering when no tabs set

### Core wiring (`tui_plan.go`)
- `syncTabs()` rebuilds tabs from: default + work tiles + active plan sessions
- `activateTab()` handles switching between Main/Work/Plan tabs
- Default pi session spawned at startup (main repo dir, no prompt)
- Keyboard input forwarded to PTY when session panel is focused

### New layouts (`tui_plan_render.go`)
- `renderSessionFullscreen()` for Main tab, Plan tabs, and maximized sessions
- `renderWorkTabContent()` splits work details (top ~40%) + session (bottom ~60%)

### Default session (`tui_plan_work.go`)
- `spawnDefaultSession()` launches pi in the main repo dir at startup

## Key Bindings

| Key | Action |
|-----|--------|
| `0` | Switch to Main tab |
| `1-9` | Select work tab by index |
| `z` | Maximize/restore session panel |
| `ctrl+1/2/3` | Switch agent/console/plan sub-session |
| `Tab` | Cycle: work details → session → issues |
| `p` | Start plan session (creates plan tab) |
| `Esc` | Exit session focus / deselect work |

Closes main-ow5d