### PR TITLE
fix: TUI UX - show issues list on startup, allow closing main session, fix Main tab click

### DIFF
--- a/.beans/main-dwss--tui-ux-fixes-issues-list-on-startup-close-main-ses.md
+++ b/.beans/main-dwss--tui-ux-fixes-issues-list-on-startup-close-main-ses.md
@@ -1,0 +1,29 @@
+---
+# main-dwss
+title: 'TUI UX fixes: issues list on startup, close main session, click main tab'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-03-12T12:38:18Z
+updated_at: 2026-03-12T12:39:58Z
+---
+
+Three UX issues:
+1. When the TUI starts for the first time there's no issues list visible
+2. When the main session is open there's no way to close it
+3. Clicking on the main work tab doesn't actually work
+
+## Tasks
+- [x] Fix issues list not showing on first start (Main tab takes over full screen)
+- [x] Add a way to close/exit the main session (e.g., Esc key)
+- [x] Fix clicking on the Main tab in the work tabs bar
+
+## Summary of Changes
+
+Modified `internal/tui/tui_plan.go` to fix three UX issues:
+
+1. **Issues list not showing on first start**: Changed `View()` so WorkTabDefault only renders fullscreen session when `activePanel == PanelSession`, otherwise falls through to the normal two-column layout. Since the initial state is `PanelLeft`, users now see the issues list on startup.
+
+2. **No way to close main session**: Updated the Esc key handler so pressing Esc while in the Main tab's session view sets `activePanel = PanelLeft`, returning to the issues list.
+
+3. **Clicking Main tab doesn't work**: Fixed `activateTab()` to toggle the Main tab between session view and issues list when clicked while already active. Also updated `IsShowingSession()` and `hasRawSessionContent()` to be consistent with the new Main tab behavior.

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -282,7 +282,10 @@ func (m *planModel) hasRawSessionContent() bool {
 		return false
 	}
 	switch activeTab.Type {
-	case WorkTabDefault, WorkTabPlan:
+	case WorkTabDefault:
+		// Only has raw content when session panel is focused (fullscreen mode)
+		return m.activePanel == PanelSession
+	case WorkTabPlan:
 		return true
 	case WorkTabWork:
 		// Both maximized and split views contain raw VT output
@@ -302,7 +305,10 @@ func (m *planModel) IsShowingSession() bool {
 		return false
 	}
 	switch activeTab.Type {
-	case WorkTabDefault, WorkTabPlan:
+	case WorkTabDefault:
+		// Only showing session when session panel is focused (fullscreen mode)
+		return m.activePanel == PanelSession
+	case WorkTabPlan:
 		return true
 	case WorkTabWork:
 		return activeTab.SessionMaximized
@@ -1072,8 +1078,11 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 						activeTab.SessionMaximized = false
 					}
 					m.activePanel = PanelWorkDetails
+				} else if activeTab.Type == WorkTabDefault {
+					// Main tab: exit session view and show issues list
+					m.activePanel = PanelLeft
 				} else {
-					// Main or plan tab: switch to main tab
+					// Plan tab: switch to main tab and show issues list
 					m.activeTabID = "main"
 					m.activePanel = PanelLeft
 					m.focusedWorkID = ""
@@ -2085,8 +2094,19 @@ func (m *planModel) activateTab(tabID string) (*planModel, tea.Cmd) {
 		return m.activateTabLegacy(tabID)
 	}
 
-	// If clicking the already-active tab, toggle it off (back to Main)
-	if m.activeTabID == tabID && tab.Type != WorkTabDefault {
+	// If clicking the already-active tab, toggle it
+	if m.activeTabID == tabID {
+		if tab.Type == WorkTabDefault {
+			// Main tab: toggle between session view and issues list
+			if m.activePanel == PanelSession {
+				m.activePanel = PanelLeft
+			} else {
+				m.activePanel = PanelSession
+				m.viewPTYSession("main")
+			}
+			return m, nil
+		}
+		// Other tabs: toggle off (back to Main)
 		m.activeTabID = "main"
 		m.focusedWorkID = ""
 		m.filters.task = ""
@@ -2102,16 +2122,14 @@ func (m *planModel) activateTab(tabID string) (*planModel, tea.Cmd) {
 
 	switch tab.Type {
 	case WorkTabDefault:
-		// Main tab: show session, clear work focus
+		// Main tab: show issues list, clear work focus
 		m.focusedWorkID = ""
 		m.filters.task = ""
 		m.filters.children = ""
-		m.activePanel = PanelSession
-		// Wire session panel to the main session
-		m.viewPTYSession("main")
-		m.statusMessage = "Main session"
+		m.activePanel = PanelLeft
+		m.statusMessage = ""
 		m.statusIsError = false
-		return m, nil
+		return m, m.refreshData()
 
 	case WorkTabWork:
 		// Work tab: focus the work (same as before)
@@ -2347,8 +2365,13 @@ func (m *planModel) View() string {
 	if activeTab != nil && m.viewMode == ViewNormal {
 		switch activeTab.Type {
 		case WorkTabDefault:
-			// Main tab: full-screen session panel
-			content = m.renderSessionFullscreen()
+			// Main tab: full-screen session when session panel is focused,
+			// otherwise show normal two-column issues layout
+			if m.activePanel == PanelSession {
+				content = m.renderSessionFullscreen()
+			} else {
+				content = m.renderTwoColumnLayout()
+			}
 
 		case WorkTabPlan:
 			// Plan tab: full-screen session panel


### PR DESCRIPTION
## Summary

Three UX fixes for the TUI:

### 1. Issues list not visible on first start
The Main tab always rendered a fullscreen session, so on startup there was no issues list. Now `WorkTabDefault` only renders fullscreen when `activePanel == PanelSession`. Since the initial state is `PanelLeft`, users see the issues list on startup.

### 2. No way to close/exit the main session
Pressing Esc in the Main tab's session view now returns to the issues list (`activePanel = PanelLeft`).

### 3. Clicking Main tab didn't work
`activateTab()` now toggles the Main tab between session view and issues list when clicked while already active. Switching to Main from other tabs shows the issues list. `IsShowingSession()` and `hasRawSessionContent()` updated to match.

## Test Plan
- Start TUI → issues list should be visible (not fullscreen session)
- Press `1` or click Main tab → fullscreen session appears
- Press `Esc` → back to issues list
- Click Main tab again → toggles to session view
- Click Main tab while on session → toggles back to issues list
- Switch to a work tab, then click Main → issues list shown

Closes main-dwss