### PR TITLE
Fix auto workflow startup, sequencer hangs, and TUI session visibility

### DIFF
--- a/.beans/main-14yj--sequencer-uses-headless-bridge-sessions-instead-of.md
+++ b/.beans/main-14yj--sequencer-uses-headless-bridge-sessions-instead-of.md
@@ -1,0 +1,21 @@
+---
+# main-14yj
+title: Sequencer uses headless bridge sessions instead of viewable PTY sessions
+status: completed
+type: bug
+created_at: 2026-03-12T17:07:15Z
+updated_at: 2026-03-12T17:07:15Z
+---
+
+The task sequencer spawned pi in RPC mode via bridge sessions, which are headless and invisible in the TUI. Replaced with PTY sessions that use InitialPrompt to send the task prompt. PTY sessions are visible in the TUI session viewer, so users can watch agent progress.
+
+- [x] Replace bridge.Bridge with ptysession.Manager in Sequencer
+- [x] Spawn PTY sessions with InitialPrompt instead of bridge RPC sessions
+- [x] Wait for process exit instead of bridge EventAgentEnd
+- [x] Update killAllActiveSessions to use ptyManager
+- [x] Update TUI to pass ptyManager to sequencer
+- [x] Fix tests
+
+## Summary of Changes
+
+Replaced the sequencer's bridge-based (headless RPC) session spawning with PTY sessions. Task sessions now appear in the TUI session viewer with IDs like task-w-xxx.N, so users can see agent output in real time. The pi process runs normally (not RPC mode) and exits when done, eliminating the prior hang issue as well.

--- a/.beans/main-zkqk--auto-work-not-started-after-worktree-creation.md
+++ b/.beans/main-zkqk--auto-work-not-started-after-worktree-creation.md
@@ -1,10 +1,11 @@
 ---
 # main-zkqk
 title: Auto work not started after worktree creation
-status: in-progress
+status: completed
 type: bug
+priority: normal
 created_at: 2026-03-12T16:41:57Z
-updated_at: 2026-03-12T16:41:57Z
+updated_at: 2026-03-12T16:49:39Z
 ---
 
 When work is created with auto=true, the control plane creates the worktree successfully but never triggers the automated workflow (estimate → implement). The auto-setup code was inside executeTask() in the sequencer, which only runs when there's already a task — but for fresh auto work there are no tasks yet, so it was unreachable dead code.
@@ -14,3 +15,15 @@ Fix: move the auto workflow setup into tryStartNextTask(), where the sequencer c
 - [x] Move auto workflow setup from executeTask to tryStartNextTask
 - [x] Remove dead code in executeTask
 - [x] Verify build and tests pass
+
+## Summary of Changes
+
+Moved auto workflow initialization from `executeTask()` (dead code — unreachable for fresh work with no tasks) to `tryStartNextTask()` in the sequencer. Now when the sequencer polls and finds an auto work with a ready worktree but zero tasks, it creates the estimate task to kick off the automated workflow.
+
+## Additional Fix: Sequencer stuck after task completion
+
+The sequencer's `waitForCompletion` called `session.Wait()` after receiving `EventAgentEnd`, which blocks until the pi process exits. But in RPC mode, pi stays alive waiting for the next prompt after finishing a turn — it never exits on its own. This caused the sequencer goroutine to hang indefinitely after every task completion.
+
+Fix: return `nil` on `EventAgentEnd` instead of waiting for process exit. The caller already calls `KillSession` to clean up the process.
+
+- [x] Fix waitForCompletion to not block on process exit after EventAgentEnd

--- a/.beans/main-zkqk--auto-work-not-started-after-worktree-creation.md
+++ b/.beans/main-zkqk--auto-work-not-started-after-worktree-creation.md
@@ -1,0 +1,16 @@
+---
+# main-zkqk
+title: Auto work not started after worktree creation
+status: in-progress
+type: bug
+created_at: 2026-03-12T16:41:57Z
+updated_at: 2026-03-12T16:41:57Z
+---
+
+When work is created with auto=true, the control plane creates the worktree successfully but never triggers the automated workflow (estimate → implement). The auto-setup code was inside executeTask() in the sequencer, which only runs when there's already a task — but for fresh auto work there are no tasks yet, so it was unreachable dead code.
+
+Fix: move the auto workflow setup into tryStartNextTask(), where the sequencer checks for ready tasks. When no ready tasks exist for an auto work with a ready worktree and zero tasks, create the estimate task. Remove the dead code from executeTask().
+
+- [x] Move auto workflow setup from executeTask to tryStartNextTask
+- [x] Remove dead code in executeTask
+- [x] Verify build and tests pass

--- a/internal/taskseq/sequencer.go
+++ b/internal/taskseq/sequencer.go
@@ -140,6 +140,19 @@ func (s *Sequencer) tryStartNextTask(ctx context.Context, w *db.Work) {
 	}
 
 	if len(readyTasks) == 0 {
+		// For auto works with no tasks yet, set up the automated workflow
+		// (create estimate task) once the worktree is ready.
+		if w.Auto && w.WorktreePath != "" {
+			allTasks, err := s.proj.DB.GetWorkTasks(ctx, w.ID)
+			if err == nil && len(allTasks) == 0 {
+				logging.Info("Setting up automated workflow for auto work", "work_id", w.ID)
+				workSvc := work.NewWorkService(s.proj)
+				if err := workSvc.CreateEstimateTaskFromWorkBeans(ctx, w.ID, os.Stdout); err != nil {
+					logging.Warn("failed to create estimate task for auto work", "error", err, "work_id", w.ID)
+				}
+				return // Let the next poll pick up the new estimate task
+			}
+		}
 		// Check if we should transition work to idle/failed
 		s.checkWorkStatus(ctx, w)
 		return
@@ -174,19 +187,6 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 	// Update activity
 	if err := s.proj.DB.UpdateTaskActivity(ctx, t.ID, time.Now()); err != nil {
 		logging.Warn("failed to update task activity", "error", err, "task_id", t.ID)
-	}
-
-	// Set up automated workflow if needed (auto work with no tasks yet)
-	if w.Auto {
-		tasks, err := s.proj.DB.GetWorkTasks(ctx, w.ID)
-		if err == nil && len(tasks) == 0 {
-			logging.Info("Setting up automated workflow", "work_id", w.ID)
-			workSvc := work.NewWorkService(s.proj)
-			if err := workSvc.CreateEstimateTaskFromWorkBeans(ctx, w.ID, os.Stdout); err != nil {
-				logging.Warn("failed to create estimate task", "error", err, "work_id", w.ID)
-			}
-			return // Let the next poll pick up the new estimate task
-		}
 	}
 
 	// Build task input

--- a/internal/taskseq/sequencer.go
+++ b/internal/taskseq/sequencer.go
@@ -358,8 +358,10 @@ func (s *Sequencer) waitForCompletion(ctx context.Context, session *bridge.Sessi
 				return session.Err()
 			}
 			if evt.Type == bridge.EventAgentEnd {
-				// Agent finished - wait for process to exit
-				return session.Wait()
+				// Agent finished its turn. In RPC mode the pi process stays
+				// alive waiting for the next prompt, so we must not block on
+				// process exit here. The caller will KillSession to clean up.
+				return nil
 			}
 		}
 	}

--- a/internal/taskseq/sequencer.go
+++ b/internal/taskseq/sequencer.go
@@ -1,12 +1,11 @@
 // Package taskseq provides an in-process task sequencer that replaces the
 // orchestrate command. It watches all works for ready tasks and executes them
-// via bridge sessions, handling post-task logic (post-estimation, review loops)
+// via PTY sessions, handling post-task logic (post-estimation, review loops)
 // inline.
 package taskseq
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -15,21 +14,21 @@ import (
 	"github.com/sargehq/sarge/internal/agents"
 	agenttypes "github.com/sargehq/sarge/internal/agents/types"
 	"github.com/sargehq/sarge/internal/beans"
-	"github.com/sargehq/sarge/internal/bridge"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/feedback"
 	"github.com/sargehq/sarge/internal/logging"
 	"github.com/sargehq/sarge/internal/orchestration"
 	"github.com/sargehq/sarge/internal/project"
+	"github.com/sargehq/sarge/internal/ptysession"
 	"github.com/sargehq/sarge/internal/task"
 	"github.com/sargehq/sarge/internal/work"
 )
 
-// Sequencer watches all works for ready tasks and executes them via bridge sessions.
+// Sequencer watches all works for ready tasks and executes them via PTY sessions.
 // It replaces the per-work orchestrator process with a single in-process goroutine.
 type Sequencer struct {
-	proj   *project.Project
-	bridge *bridge.Bridge
+	proj       *project.Project
+	ptyManager *ptysession.Manager
 
 	mu          sync.Mutex
 	activeTasks map[string]string // workID → taskID currently executing
@@ -41,11 +40,11 @@ type Sequencer struct {
 	notify chan struct{}
 }
 
-// New creates a new Sequencer. The bridge is shared with the TUI for session viewing.
-func New(proj *project.Project, b *bridge.Bridge) *Sequencer {
+// New creates a new Sequencer. The PTY manager is shared with the TUI for session viewing.
+func New(proj *project.Project, ptyMgr *ptysession.Manager) *Sequencer {
 	return &Sequencer{
 		proj:        proj,
-		bridge:      b,
+		ptyManager:  ptyMgr,
 		activeTasks: make(map[string]string),
 		done:        make(chan struct{}),
 		notify:      make(chan struct{}, 1),
@@ -169,7 +168,7 @@ func (s *Sequencer) tryStartNextTask(ctx context.Context, w *db.Work) {
 	go s.executeTask(ctx, w, t)
 }
 
-// executeTask runs a single task via bridge session and handles post-task logic.
+// executeTask runs a single task via PTY session and handles post-task logic.
 func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 	defer func() {
 		s.mu.Lock()
@@ -179,7 +178,7 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 		s.Notify()
 	}()
 
-	logging.Info("Executing task via bridge",
+	logging.Info("Executing task",
 		"task_id", t.ID,
 		"task_type", t.TaskType,
 		"work_id", w.ID)
@@ -234,69 +233,88 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 	taskCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Spawn bridge session
+	// Spawn PTY session
 	sessionID := fmt.Sprintf("task-%s", t.ID)
-	sessionCfg := bridge.SessionConfigFromProject(w.WorktreePath, s.proj.Config)
-	sessionCfg.Env = append(sessionCfg.Env, fmt.Sprintf("SARGE_TASK_ID=%s", t.ID))
-	sessionCfg.Env = append(sessionCfg.Env, fmt.Sprintf("BEANS_PATH=%s", s.proj.BeansPath()))
+	ptyCfg := ptysession.SessionConfig{
+		Args:          []string{"--no-session"},
+		WorkDir:       w.WorktreePath,
+		Width:         120,
+		Height:        40,
+		InitialPrompt: prompt,
+	}
 
-	// Apply hooks.env
-	for _, e := range s.proj.Config.Hooks.Env {
-		expandedValue := os.ExpandEnv(e)
-		sessionCfg.Env = append(sessionCfg.Env, expandedValue)
+	if s.proj.Config != nil {
+		if s.proj.Config.Pi.Provider != "" {
+			ptyCfg.Args = append(ptyCfg.Args, "--provider", s.proj.Config.Pi.Provider)
+		}
+		if s.proj.Config.Pi.Model != "" {
+			ptyCfg.Args = append(ptyCfg.Args, "--model", s.proj.Config.Pi.Model)
+		}
+		if s.proj.Config.Pi.Thinking != "" {
+			ptyCfg.Args = append(ptyCfg.Args, "--thinking", s.proj.Config.Pi.Thinking)
+		}
 	}
 
 	// Use task-specific args (e.g. model override for log_analysis)
 	if t.TaskType == "log_analysis" && s.proj.Config.LogParser.GetModel() != "" {
-		sessionCfg.Model = s.proj.Config.LogParser.GetModel()
+		ptyCfg.Args = append(ptyCfg.Args, "--model", s.proj.Config.LogParser.GetModel())
 	}
 
-	session, err := s.bridge.SpawnSession(sessionID, sessionCfg)
+	ptyCfg.Env = append(os.Environ(),
+		fmt.Sprintf("SARGE_TASK_ID=%s", t.ID),
+		fmt.Sprintf("BEANS_PATH=%s", s.proj.BeansPath()),
+	)
+
+	// Apply hooks.env
+	for _, e := range s.proj.Config.Hooks.Env {
+		ptyCfg.Env = append(ptyCfg.Env, os.ExpandEnv(e))
+	}
+
+	session, err := s.ptyManager.Spawn(sessionID, ptyCfg)
 	if err != nil {
-		logging.Error("Failed to spawn bridge session", "error", err, "task_id", t.ID)
-		if dbErr := s.proj.DB.FailTask(ctx, t.ID, fmt.Sprintf("failed to spawn bridge session: %v", err)); dbErr != nil {
+		logging.Error("Failed to spawn PTY session", "error", err, "task_id", t.ID)
+		if dbErr := s.proj.DB.FailTask(ctx, t.ID, fmt.Sprintf("failed to spawn PTY session: %v", err)); dbErr != nil {
 			logging.Warn("failed to mark task as failed", "error", dbErr)
 		}
 		return
 	}
 
-	// Send prompt
-	if err := session.Prompt(prompt); err != nil {
-		logging.Error("Failed to send prompt", "error", err, "task_id", t.ID)
-		_ = s.bridge.KillSession(sessionID)
-		if dbErr := s.proj.DB.FailTask(ctx, t.ID, fmt.Sprintf("failed to send prompt: %v", err)); dbErr != nil {
-			logging.Warn("failed to mark task as failed", "error", dbErr)
-		}
-		return
-	}
-
-	// Wait for agent to complete
+	// Wait for pi process to exit or timeout
 	startTime := time.Now()
-	err = s.waitForCompletion(taskCtx, session, t.ID)
+	exited := make(chan struct{})
+	go func() {
+		session.Wait()
+		close(exited)
+	}()
 
-	// Clean up session
-	_ = s.bridge.KillSession(sessionID)
-
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+	select {
+	case <-exited:
+		// Process exited normally
+	case <-taskCtx.Done():
+		if taskCtx.Err() == context.DeadlineExceeded {
 			logging.Warn("Task timed out", "task_id", t.ID, "timeout", timeout)
+			_ = s.ptyManager.Kill(sessionID)
 			if dbErr := s.proj.DB.FailTask(context.Background(), t.ID, fmt.Sprintf("task timed out after %v", timeout)); dbErr != nil {
 				logging.Warn("failed to mark timed out task as failed", "error", dbErr)
 			}
 			return
 		}
-		if errors.Is(err, context.Canceled) {
-			logging.Info("Task cancelled", "task_id", t.ID)
-			return
-		}
+		logging.Info("Task cancelled", "task_id", t.ID)
+		_ = s.ptyManager.Kill(sessionID)
+		return
+	}
+
+	elapsed := time.Since(startTime)
+
+	// Check if agent exited with error
+	if sessionErr := session.Err(); sessionErr != nil {
 		// Agent exited with error - check if task was already marked complete/failed
 		updatedTask, dbErr := s.proj.DB.GetTask(ctx, t.ID)
 		if dbErr == nil && updatedTask != nil && (updatedTask.Status == db.StatusCompleted || updatedTask.Status == db.StatusFailed) {
-			elapsed := time.Since(startTime)
 			logging.Info("Task finished", "task_id", t.ID, "status", updatedTask.Status, "elapsed", elapsed.Round(time.Second))
 		} else {
-			logging.Error("Agent exited with error", "error", err, "task_id", t.ID)
-			if dbErr := s.proj.DB.FailTask(ctx, t.ID, fmt.Sprintf("agent exited with error: %v", err)); dbErr != nil {
+			logging.Error("Agent exited with error", "error", sessionErr, "task_id", t.ID)
+			if dbErr := s.proj.DB.FailTask(ctx, t.ID, fmt.Sprintf("agent exited with error: %v", sessionErr)); dbErr != nil {
 				logging.Warn("failed to mark task as failed", "error", dbErr)
 			}
 			return
@@ -338,34 +356,13 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 		}
 	}
 
-	elapsed := time.Since(startTime)
 	logging.Info("Task execution complete",
 		"task_id", t.ID,
 		"task_type", t.TaskType,
-		"elapsed", elapsed.Round(time.Second))
+		"elapsed", time.Since(startTime).Round(time.Second))
 }
 
-// waitForCompletion blocks until the bridge session ends or context is cancelled.
-func (s *Sequencer) waitForCompletion(ctx context.Context, session *bridge.Session, _ string) error {
-	for {
-		select {
-		case <-ctx.Done():
-			_ = session.Abort()
-			return ctx.Err()
-		case evt, ok := <-session.Events():
-			if !ok {
-				// Session events channel closed = process exited
-				return session.Err()
-			}
-			if evt.Type == bridge.EventAgentEnd {
-				// Agent finished its turn. In RPC mode the pi process stays
-				// alive waiting for the next prompt, so we must not block on
-				// process exit here. The caller will KillSession to clean up.
-				return nil
-			}
-		}
-	}
-}
+
 
 // checkWorkStatus transitions work to idle/failed based on task statuses.
 func (s *Sequencer) checkWorkStatus(ctx context.Context, w *db.Work) {
@@ -433,7 +430,7 @@ func (s *Sequencer) resetAllStuckTasks(ctx context.Context) {
 	}
 }
 
-// killAllActiveSessions kills bridge sessions for all active tasks.
+// killAllActiveSessions kills PTY sessions for all active tasks.
 func (s *Sequencer) killAllActiveSessions() {
 	s.mu.Lock()
 	tasks := make(map[string]string, len(s.activeTasks))
@@ -444,7 +441,7 @@ func (s *Sequencer) killAllActiveSessions() {
 
 	for _, taskID := range tasks {
 		sessionID := fmt.Sprintf("task-%s", taskID)
-		_ = s.bridge.KillSession(sessionID)
+		_ = s.ptyManager.Kill(sessionID)
 	}
 }
 

--- a/internal/taskseq/sequencer_test.go
+++ b/internal/taskseq/sequencer_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sargehq/sarge/internal/bridge"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/project"
+	"github.com/sargehq/sarge/internal/ptysession"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,13 +38,13 @@ func newTestProject(t *testing.T) *project.Project {
 	}
 }
 
-// newTestSequencer creates a sequencer with a test project and bridge.
+// newTestSequencer creates a sequencer with a test project and PTY manager.
 func newTestSequencer(t *testing.T) (*Sequencer, *project.Project) {
 	t.Helper()
 	proj := newTestProject(t)
-	b := bridge.NewBridge()
-	t.Cleanup(func() { b.KillAll() })
-	s := New(proj, b)
+	ptyMgr := ptysession.NewManager()
+	t.Cleanup(func() { ptyMgr.KillAll() })
+	s := New(proj, ptyMgr)
 	return s, proj
 }
 

--- a/internal/tui/tui_panel_session_picker.go
+++ b/internal/tui/tui_panel_session_picker.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/sargehq/sarge/internal/bridge"
+	"github.com/sargehq/sarge/internal/ptysession"
 )
 
 // SessionPickerAction represents an action from the session picker.
@@ -19,14 +19,14 @@ const (
 	SessionPickerActionSelect                     // User pressed Enter
 )
 
-// sessionPickerEntry represents a bridge session in the picker list.
+// sessionPickerEntry represents a session in the picker list.
 type sessionPickerEntry struct {
 	ID    string
-	Type  string // "orch", "agent", "plan"
-	State bridge.SessionState
+	Type  string // "task", "agent", "plan", "console", "main"
+	State ptysession.SessionState
 }
 
-// SessionPickerPanel shows a filterable list of bridge sessions for a work.
+// SessionPickerPanel shows a filterable list of sessions for a work.
 type SessionPickerPanel struct {
 	width  int
 	height int
@@ -56,16 +56,20 @@ func (p *SessionPickerPanel) Init() tea.Cmd {
 	return textinput.Blink
 }
 
-// SetSessions populates the picker from a bridge.
-func (p *SessionPickerPanel) SetSessions(sessions map[string]bridge.SessionState) {
+// SetSessions populates the picker from PTY session states.
+func (p *SessionPickerPanel) SetSessions(sessions map[string]ptysession.SessionState) {
 	p.sessions = nil
 	for id, state := range sessions {
 		// Infer type from ID naming convention
-		sessionType := "orch"
-		if strings.Contains(id, "agent") {
+		sessionType := "main"
+		if strings.Contains(id, "task") {
+			sessionType = "task"
+		} else if strings.Contains(id, "agent") {
 			sessionType = "agent"
 		} else if strings.Contains(id, "plan") {
 			sessionType = "plan"
+		} else if strings.Contains(id, "console") {
+			sessionType = "console"
 		}
 		p.sessions = append(p.sessions, sessionPickerEntry{
 			ID:    id,
@@ -160,14 +164,14 @@ func (p *SessionPickerPanel) View() string {
 
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Select bridge session"))
+	b.WriteString(titleStyle.Render("Select session"))
 	b.WriteString("\n\n")
 	b.WriteString(p.filter.View())
 	b.WriteString("\n\n")
 
 	if len(p.filtered) == 0 {
 		if len(p.sessions) == 0 {
-			b.WriteString(dimStyle.Render("No active bridge sessions"))
+			b.WriteString(dimStyle.Render("No active sessions"))
 		} else {
 			b.WriteString(dimStyle.Render("No matching sessions"))
 		}
@@ -190,11 +194,9 @@ func (p *SessionPickerPanel) View() string {
 			s := p.filtered[i]
 			stateIcon := "○"
 			switch s.State {
-			case bridge.SessionReady:
+			case ptysession.SessionRunning:
 				stateIcon = "●"
-			case bridge.SessionStreaming:
-				stateIcon = "◉"
-			case bridge.SessionDead:
+			case ptysession.SessionDead:
 				stateIcon = "✗"
 			}
 			label := fmt.Sprintf("%s [%s] %s", stateIcon, s.Type, s.ID)

--- a/internal/tui/tui_panel_work_tabs.go
+++ b/internal/tui/tui_panel_work_tabs.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"image/color"
+	"strings"
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
@@ -296,13 +297,14 @@ func (b *WorkTabsBar) renderTabs() string {
 
 		// Sub-session indicator for work tabs
 		subIndicator := ""
-		if tab.Type == WorkTabWork {
-			switch tab.ActiveSubSession {
-			case SubSessionAgent:
-				// No indicator — agent is default
-			case SubSessionConsole:
+		if tab.Type == WorkTabWork && tab.ActiveSessionID != "" {
+			// Show short label if not the default
+			if strings.Contains(tab.ActiveSessionID, "task-") {
+				suffix := tab.ActiveSessionID[strings.LastIndex(tab.ActiveSessionID, "."):]
+				subIndicator = " [t" + suffix + "]"
+			} else if strings.Contains(tab.ActiveSessionID, "console-") {
 				subIndicator = " [sh]"
-			case SubSessionPlan:
+			} else if strings.Contains(tab.ActiveSessionID, "plan-") {
 				subIndicator = " [pl]"
 			}
 		}

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -749,7 +749,7 @@ func (m *planModel) Update(msg tea.Msg) (*planModel, tea.Cmd) {
 			// If we're on the work tab for this work, just stay there
 			// The session will render in the embedded panel
 			if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork && activeTab.WorkID == msg.workID {
-				activeTab.ActiveSubSession = SubSessionAgent
+				activeTab.ActiveSessionID = msg.ptySessionID
 			}
 			m.statusMessage = fmt.Sprintf("Agent session opened for %s", msg.workID)
 			m.statusIsError = false
@@ -1477,8 +1477,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 				if hasSession && !activeTab.SessionMaximized {
 					// Move from work details to session panel
 					m.activePanel = PanelSession
-					sessionID := activeTab.SessionID()
-					if s := m.ptyManager.Get(sessionID); s != nil {
+					if sessionID := activeTab.ResolveSessionID(m.ptyManager); sessionID != "" {
 						m.viewPTYSession(sessionID)
 					}
 				} else {
@@ -1644,34 +1643,13 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, m.refreshData()
 
-	case "ctrl+1":
-		// Switch to agent sub-session
+	case "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4", "ctrl+5", "ctrl+6", "ctrl+7", "ctrl+8", "ctrl+9":
+		// Switch to sub-session by index
 		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-			activeTab.SetSubSession(1)
-			sessionID := activeTab.SessionID()
-			if s := m.ptyManager.Get(sessionID); s != nil {
-				m.viewPTYSession(sessionID)
-			}
-		}
-		return m, nil
-
-	case "ctrl+2":
-		// Switch to console sub-session
-		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-			activeTab.SetSubSession(2)
-			sessionID := activeTab.SessionID()
-			if s := m.ptyManager.Get(sessionID); s != nil {
-				m.viewPTYSession(sessionID)
-			}
-		}
-		return m, nil
-
-	case "ctrl+3":
-		// Switch to plan sub-session
-		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-			activeTab.SetSubSession(3)
-			sessionID := activeTab.SessionID()
-			if s := m.ptyManager.Get(sessionID); s != nil {
+			idx := int(msg.String()[len(msg.String())-1] - '0')
+			activeTab.SetSubSessionByIndex(m.ptyManager, idx)
+			sessionID := activeTab.ResolveSessionID(m.ptyManager)
+			if sessionID != "" {
 				m.viewPTYSession(sessionID)
 			}
 		}
@@ -1684,8 +1662,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 			if activeTab.SessionMaximized {
 				m.activePanel = PanelSession
 				// Wire session panel to the tab's active session
-				sessionID := activeTab.SessionID()
-				if s := m.ptyManager.Get(sessionID); s != nil {
+				if sessionID := activeTab.ResolveSessionID(m.ptyManager); sessionID != "" {
 					m.viewPTYSession(sessionID)
 				}
 			} else {
@@ -1885,18 +1862,6 @@ func (m *planModel) cleanup() {
 	}
 	// Note: m.proj.Beans is owned by the Project and closed by proj.Close()
 	// which is deferred in runTUI. Do not close it here to avoid double-close.
-}
-
-// findActiveTaskSession returns the session ID of a running task session for the given work,
-// or empty string if none found.
-func (m *planModel) findActiveTaskSession(workID string) string {
-	prefix := "task-" + workID + "."
-	for id, state := range m.ptyManager.List() {
-		if state != ptysession.SessionDead && len(id) > len(prefix) && id[:len(prefix)] == prefix {
-			return id
-		}
-	}
-	return ""
 }
 
 // viewPTYSession switches the session panel to display a specific PTY session.
@@ -2135,13 +2100,9 @@ func (m *planModel) activateTab(tabID string) (*planModel, tea.Cmd) {
 		m.workDetails.SetSelectedIndex(0)
 		m.workDetails.SetOrchestratorHealth(checkOrchestratorHealth(m.ctx, m.proj.DB, m.focusedWorkID))
 
-		// Wire session panel to the active sub-session.
-		// If the preferred session doesn't exist, look for an active task session.
-		sessionID := tab.SessionID()
-		if s := m.ptyManager.Get(sessionID); s != nil && s.State() != ptysession.SessionDead {
+		// Wire session panel to the best available session
+		if sessionID := tab.ResolveSessionID(m.ptyManager); sessionID != "" {
 			m.viewPTYSession(sessionID)
-		} else if taskSessionID := m.findActiveTaskSession(tab.WorkID); taskSessionID != "" {
-			m.viewPTYSession(taskSessionID)
 		}
 
 		return m, m.updateWorkSelectionFilter()

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -1887,6 +1887,18 @@ func (m *planModel) cleanup() {
 	// which is deferred in runTUI. Do not close it here to avoid double-close.
 }
 
+// findActiveTaskSession returns the session ID of a running task session for the given work,
+// or empty string if none found.
+func (m *planModel) findActiveTaskSession(workID string) string {
+	prefix := "task-" + workID + "."
+	for id, state := range m.ptyManager.List() {
+		if state != ptysession.SessionDead && len(id) > len(prefix) && id[:len(prefix)] == prefix {
+			return id
+		}
+	}
+	return ""
+}
+
 // viewPTYSession switches the session panel to display a specific PTY session.
 func (m *planModel) viewPTYSession(sessionID string) {
 	m.activeSessionID = sessionID
@@ -2123,10 +2135,13 @@ func (m *planModel) activateTab(tabID string) (*planModel, tea.Cmd) {
 		m.workDetails.SetSelectedIndex(0)
 		m.workDetails.SetOrchestratorHealth(checkOrchestratorHealth(m.ctx, m.proj.DB, m.focusedWorkID))
 
-		// Wire session panel to the active sub-session
+		// Wire session panel to the active sub-session.
+		// If the preferred session doesn't exist, look for an active task session.
 		sessionID := tab.SessionID()
-		if s := m.ptyManager.Get(sessionID); s != nil {
+		if s := m.ptyManager.Get(sessionID); s != nil && s.State() != ptysession.SessionDead {
 			m.viewPTYSession(sessionID)
+		} else if taskSessionID := m.findActiveTaskSession(tab.WorkID); taskSessionID != "" {
+			m.viewPTYSession(taskSessionID)
 		}
 
 		return m, m.updateWorkSelectionFilter()

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -16,7 +16,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/sargehq/sarge/internal/beans"
 	beanswatcher "github.com/sargehq/sarge/internal/beans/watcher"
-	"github.com/sargehq/sarge/internal/bridge"
 	"github.com/sargehq/sarge/internal/git"
 	"github.com/sargehq/sarge/internal/progress"
 	"github.com/sargehq/sarge/internal/project"
@@ -58,8 +57,7 @@ type planModel struct {
 
 
 	// Session support
-	bridgeClient        *bridge.Bridge          // For headless sequencer sessions only
-	ptyManager          *ptysession.Manager     // For interactive PTY sessions (plan/agent/console)
+	ptyManager          *ptysession.Manager     // For PTY sessions (plan/agent/console/task)
 	sessionPanel        *SessionPanel
 	sessionPicker       *SessionPickerPanel
 	activeSessionID     string // Currently viewed PTY session ID
@@ -208,7 +206,6 @@ func newPlanModel(ctx context.Context, proj *project.Project) *planModel {
 
 	m.sessionPanel = NewSessionPanel()
 	m.sessionPicker = NewSessionPickerPanel()
-	m.bridgeClient = bridge.NewBridge()
 	m.ptyManager = ptysession.NewManager()
 
 	// Initialize tab model with the default "Main" tab
@@ -216,11 +213,9 @@ func newPlanModel(ctx context.Context, proj *project.Project) *planModel {
 	m.tabs = []*WorkTab{defaultTab}
 	m.activeTabID = defaultTab.ID
 
-	// Wire PTY manager and bridge into the WorkService's OrchestratorManager.
-	// PTY sessions are used for interactive display (plan/agent/console).
-	// Bridge sessions are used by the sequencer for headless task execution.
-	m.workService.OrchestratorManager = work.NewOrchestratorManagerWithBridge(
-		proj.DB, proj.Config, m.bridgeClient, m.ptyManager, proj.BeansPath(),
+	// Wire PTY manager into the WorkService's OrchestratorManager.
+	m.workService.OrchestratorManager = work.NewOrchestratorManagerWithPTY(
+		proj.DB, proj.Config, m.ptyManager, proj.BeansPath(),
 	)
 
 	// Set up status bar data providers
@@ -1884,11 +1879,7 @@ func (m *planModel) cleanup() {
 	if m.beansWatcher != nil {
 		_ = m.beansWatcher.Stop()
 	}
-	// Kill all bridge sessions (headless/sequencer)
-	if m.bridgeClient != nil {
-		_ = m.bridgeClient.KillAll()
-	}
-	// Kill all PTY sessions (interactive)
+	// Kill all PTY sessions
 	if m.ptyManager != nil {
 		_ = m.ptyManager.KillAll()
 	}
@@ -1964,20 +1955,7 @@ func (m *planModel) openBridgeSessionPicker() {
 		}
 		return
 	}
-	// Convert to the format the session picker expects
-	bridgeSessions := make(map[string]bridge.SessionState)
-	for id, state := range ptySessions {
-		// Map PTY states to bridge states for the picker UI
-		switch state {
-		case ptysession.SessionRunning:
-			bridgeSessions[id] = bridge.SessionReady
-		case ptysession.SessionDead:
-			bridgeSessions[id] = bridge.SessionDead
-		default:
-			bridgeSessions[id] = bridge.SessionStarting
-		}
-	}
-	m.sessionPicker.SetSessions(bridgeSessions)
+	m.sessionPicker.SetSessions(ptySessions)
 	m.sessionPicker.SetSize(m.width/2, m.height/2)
 	m.viewMode = ViewBridgeSessionPicker
 }

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -1416,13 +1416,11 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 			case WorkDetailActionResetTask:
 				return m, m.resetSelectedTask()
 			case WorkDetailActionAttachTerminal:
-				// Open bridge session picker
-				if m.bridgeClient != nil {
-					sessions := m.bridgeClient.ListSessions()
-					if len(sessions) > 0 {
-						m.openBridgeSessionPicker()
-						return m, nil
-					}
+				// Open session picker (checks PTY sessions)
+				ptySessions := m.ptyManager.List()
+				if len(ptySessions) > 0 {
+					m.openBridgeSessionPicker()
+					return m, nil
 				}
 				m.statusMessage = "No active sessions for this work"
 				m.statusIsError = false

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -204,8 +204,12 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 
 // renderTwoColumnLayout renders the issues and details panels side-by-side
 func (m *planModel) renderTwoColumnLayout() string {
-	// Check if a work is focused - if so, render split view
+	// Check if a work is focused - if so, render work tab content with session
 	if m.focusedWorkID != "" {
+		// Find or create a work tab to render
+		if tab := m.getTabByID(m.focusedWorkID); tab != nil && tab.Type == WorkTabWork {
+			return m.renderWorkTabContent(tab)
+		}
 		return m.renderFocusedWorkSplitView()
 	}
 

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -92,13 +93,11 @@ func (m *planModel) renderSessionFullscreen() string {
 		case WorkTabPlan:
 			title = "Plan: " + activeTab.BeanID
 		case WorkTabWork:
-			switch activeTab.ActiveSubSession {
-			case SubSessionAgent:
-				title = "Agent: " + activeTab.WorkID
-			case SubSessionConsole:
-				title = "Console: " + activeTab.WorkID
-			case SubSessionPlan:
-				title = "Plan: " + activeTab.WorkID
+			sid := activeTab.ResolveSessionID(m.ptyManager)
+			if sid != "" {
+				title = sid
+			} else {
+				title = activeTab.WorkID
 			}
 			title += " [z] restore"
 		}
@@ -149,9 +148,11 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 	workPanel := m.workDetails.RenderWithPanel(workPanelHeight)
 
 	// Render session panel (bottom) — no border, raw PTY output
-	sessionID := tab.SessionID()
-	if s := m.ptyManager.Get(sessionID); s != nil && m.sessionPanel.Session() != s {
-		m.viewPTYSession(sessionID)
+	sessionID := tab.ResolveSessionID(m.ptyManager)
+	if sessionID != "" {
+		if s := m.ptyManager.Get(sessionID); s != nil && m.sessionPanel.Session() != s {
+			m.viewPTYSession(sessionID)
+		}
 	}
 
 	// Session gets full width, height minus 1 for title bar
@@ -159,24 +160,30 @@ func (m *planModel) renderWorkTabContent(tab *WorkTab) string {
 	m.sessionPanel.SetSize(m.width, ptyHeight)
 	m.sessionPanel.SetFocus(m.activePanel == PanelSession)
 
-	// Sub-session indicator
-	subLabel := ""
-	switch tab.ActiveSubSession {
-	case SubSessionAgent:
-		subLabel = "Agent"
-	case SubSessionConsole:
-		subLabel = "Console"
-	case SubSessionPlan:
-		subLabel = "Plan"
-	}
+	// Build sub-tab bar
+	subs := tab.AvailableSessions(m.ptyManager)
+	activeIdx := tab.ActiveSubTabIndex(m.ptyManager)
 
-	// Minimal title bar (no border)
+	titleBg := lipgloss.Color("236")
 	titleStyle := lipgloss.NewStyle().
-		Background(lipgloss.Color("236")).
-		Foreground(lipgloss.Color("214")).
-		Bold(true).
+		Background(titleBg).
 		Width(m.width)
-	titleBar := titleStyle.Render(" " + subLabel + " " + tuiDimStyle.Render("[z] maximize  [ctrl+1/2/3] switch"))
+
+	var subTabStr string
+	if len(subs) == 0 {
+		subTabStr = lipgloss.NewStyle().Background(titleBg).Foreground(lipgloss.Color("244")).Render(" No sessions")
+	} else {
+		for i, sub := range subs {
+			label := fmt.Sprintf(" %d:%s ", i+1, sub.Label)
+			if i == activeIdx {
+				subTabStr += lipgloss.NewStyle().Background(lipgloss.Color("214")).Foreground(lipgloss.Color("232")).Bold(true).Render(label)
+			} else {
+				subTabStr += lipgloss.NewStyle().Background(titleBg).Foreground(lipgloss.Color("250")).Render(label)
+			}
+		}
+		subTabStr += lipgloss.NewStyle().Background(titleBg).Foreground(lipgloss.Color("240")).Render("  [z] maximize")
+	}
+	titleBar := titleStyle.Render(subTabStr)
 
 	// Render session content RAW — do not pass through lipgloss.
 	sessionContent := m.sessionPanel.Render()

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -214,7 +214,7 @@ func RunRootTUI(ctx context.Context, proj *project.Project, enableMouse bool) er
 
 	// Start the task sequencer as an in-process goroutine.
 	model := newRootModel(ctx, proj)
-	sequencer := taskseq.New(proj, model.planModel.bridgeClient)
+	sequencer := taskseq.New(proj, model.planModel.ptyManager)
 
 	// Wire up DB watcher to notify the sequencer on changes.
 	trackingDBPath := filepath.Join(proj.Root, ".co", "tracking.db")

--- a/internal/tui/tui_work_tab.go
+++ b/internal/tui/tui_work_tab.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/sargehq/sarge/internal/progress"
 	"github.com/sargehq/sarge/internal/ptysession"
 )
@@ -17,17 +20,12 @@ const (
 	WorkTabPlan
 )
 
-// WorkTabSubSession identifies which sub-session is active within a work tab.
-type WorkTabSubSession int
-
-const (
-	// SubSessionAgent is the agent/chat pi session.
-	SubSessionAgent WorkTabSubSession = iota
-	// SubSessionConsole is the terminal/console pi session.
-	SubSessionConsole
-	// SubSessionPlan is a planning pi session within a work.
-	SubSessionPlan
-)
+// SubTab represents one sub-tab within a work tab.
+type SubTab struct {
+	ID    string // PTY session ID (e.g. "task-w-5d0.2", "agent-w-5d0", "console-w-5d0")
+	Label string // Display label (e.g. "task .2", "agent", "console")
+	Type  string // "task", "agent", "console", "plan"
+}
 
 // WorkTab represents a single tab in the work tabs bar.
 // It can be a default session, a work unit, or a standalone plan session.
@@ -52,8 +50,9 @@ type WorkTab struct {
 	// WorkProgress holds cached work data (tasks, beans, etc.) for work tabs.
 	WorkProgress *progress.WorkProgress
 
-	// ActiveSubSession is which sub-session is currently shown (work tabs only).
-	ActiveSubSession WorkTabSubSession
+	// ActiveSessionID is the PTY session ID currently displayed.
+	// Empty means "auto" — pick the first available task or agent session.
+	ActiveSessionID string
 
 	// SessionMaximized is true when the session panel is zoomed to fill the content area.
 	SessionMaximized bool
@@ -62,34 +61,97 @@ type WorkTab struct {
 
 	// BeanID is set for WorkTabPlan tabs (the bean being planned).
 	BeanID string
-
-	// --- Session references ---
-	// These are looked up from the PTY manager by convention:
-	//   default:  session ID "main"
-	//   agent:    session ID "agent-<workID>"
-	//   console:  session ID "console-<workID>"
-	//   plan:     session ID "plan-<beanID>"
 }
 
-// SessionID returns the PTY session ID for the currently active session in this tab.
+// AvailableSessions returns all sub-tabs for this work, discovered from the PTY manager.
+// Returns them in a stable order: task sessions (sorted by ID), then agent, console, plan.
+func (t *WorkTab) AvailableSessions(mgr *ptysession.Manager) []SubTab {
+	if mgr == nil || t.Type != WorkTabWork {
+		return nil
+	}
+
+	var tasks []SubTab
+	var others []SubTab
+
+	prefix := t.WorkID
+	for id, state := range mgr.List() {
+		if state == ptysession.SessionDead {
+			continue
+		}
+
+		if strings.HasPrefix(id, "task-"+prefix+".") {
+			// Extract task number suffix for label (e.g., "task-w-5d0.2" -> ".2")
+			suffix := id[len("task-"+prefix):]
+			tasks = append(tasks, SubTab{
+				ID:    id,
+				Label: "task" + suffix,
+				Type:  "task",
+			})
+		} else if id == "agent-"+prefix {
+			others = append(others, SubTab{
+				ID:    id,
+				Label: "agent",
+				Type:  "agent",
+			})
+		} else if id == "console-"+prefix {
+			others = append(others, SubTab{
+				ID:    id,
+				Label: "console",
+				Type:  "console",
+			})
+		} else if id == "plan-"+prefix {
+			others = append(others, SubTab{
+				ID:    id,
+				Label: "plan",
+				Type:  "plan",
+			})
+		}
+	}
+
+	// Sort task sessions by ID for stable ordering
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].ID < tasks[j].ID })
+
+	return append(tasks, others...)
+}
+
+// SessionID returns the PTY session ID to display for this tab.
 func (t *WorkTab) SessionID() string {
 	switch t.Type {
 	case WorkTabDefault:
 		return "main"
 	case WorkTabWork:
-		switch t.ActiveSubSession {
-		case SubSessionAgent:
-			return "agent-" + t.WorkID
-		case SubSessionConsole:
-			return "console-" + t.WorkID
-		case SubSessionPlan:
-			// Plan within a work — uses the root bean ID
-			return "plan-" + t.WorkID
+		if t.ActiveSessionID != "" {
+			return t.ActiveSessionID
 		}
+		// Default: return agent session ID (may not exist)
 		return "agent-" + t.WorkID
 	case WorkTabPlan:
 		return "plan-" + t.BeanID
 	}
+	return ""
+}
+
+// ResolveSessionID picks the best available session to display.
+// If ActiveSessionID is set and alive, keeps it. Otherwise picks the first available.
+func (t *WorkTab) ResolveSessionID(mgr *ptysession.Manager) string {
+	if t.Type != WorkTabWork {
+		return t.SessionID()
+	}
+
+	// If explicitly set and still alive, use it
+	if t.ActiveSessionID != "" {
+		if s := mgr.Get(t.ActiveSessionID); s != nil && s.State() != ptysession.SessionDead {
+			return t.ActiveSessionID
+		}
+	}
+
+	// Auto-pick: first available from AvailableSessions
+	subs := t.AvailableSessions(mgr)
+	if len(subs) > 0 {
+		t.ActiveSessionID = subs[0].ID
+		return subs[0].ID
+	}
+
 	return ""
 }
 
@@ -99,7 +161,11 @@ func (t *WorkTab) ActiveSession(mgr *ptysession.Manager) *ptysession.Session {
 	if mgr == nil {
 		return nil
 	}
-	return mgr.Get(t.SessionID())
+	id := t.ResolveSessionID(mgr)
+	if id == "" {
+		return nil
+	}
+	return mgr.Get(id)
 }
 
 // HasActiveSession returns true if the tab has a running PTY session.
@@ -108,34 +174,51 @@ func (t *WorkTab) HasActiveSession(mgr *ptysession.Manager) bool {
 	return s != nil && s.State() != ptysession.SessionDead
 }
 
-// CycleSubSession cycles to the next sub-session within a work tab.
-func (t *WorkTab) CycleSubSession() {
-	if t.Type != WorkTabWork {
+// CycleSubSession cycles to the next available sub-session within a work tab.
+func (t *WorkTab) CycleSubSession(mgr *ptysession.Manager) {
+	if t.Type != WorkTabWork || mgr == nil {
 		return
 	}
-	switch t.ActiveSubSession {
-	case SubSessionAgent:
-		t.ActiveSubSession = SubSessionConsole
-	case SubSessionConsole:
-		t.ActiveSubSession = SubSessionPlan
-	case SubSessionPlan:
-		t.ActiveSubSession = SubSessionAgent
+	subs := t.AvailableSessions(mgr)
+	if len(subs) <= 1 {
+		return
 	}
+	current := t.ResolveSessionID(mgr)
+	for i, sub := range subs {
+		if sub.ID == current {
+			t.ActiveSessionID = subs[(i+1)%len(subs)].ID
+			return
+		}
+	}
+	t.ActiveSessionID = subs[0].ID
 }
 
-// SetSubSession sets the active sub-session by index (1=agent, 2=console, 3=plan).
-func (t *WorkTab) SetSubSession(index int) {
-	if t.Type != WorkTabWork {
+// SetSubSessionByIndex sets the active sub-session by 1-based index into AvailableSessions.
+func (t *WorkTab) SetSubSessionByIndex(mgr *ptysession.Manager, index int) {
+	if t.Type != WorkTabWork || mgr == nil {
 		return
 	}
-	switch index {
-	case 1:
-		t.ActiveSubSession = SubSessionAgent
-	case 2:
-		t.ActiveSubSession = SubSessionConsole
-	case 3:
-		t.ActiveSubSession = SubSessionPlan
+	subs := t.AvailableSessions(mgr)
+	if index < 1 || index > len(subs) {
+		return
 	}
+	t.ActiveSessionID = subs[index-1].ID
+}
+
+// ActiveSubTabIndex returns the 0-based index of the active session in AvailableSessions.
+// Returns -1 if not found.
+func (t *WorkTab) ActiveSubTabIndex(mgr *ptysession.Manager) int {
+	if mgr == nil {
+		return -1
+	}
+	subs := t.AvailableSessions(mgr)
+	current := t.ResolveSessionID(mgr)
+	for i, sub := range subs {
+		if sub.ID == current {
+			return i
+		}
+	}
+	return -1
 }
 
 // NewDefaultTab creates the always-present "Main" tab.
@@ -153,11 +236,10 @@ func NewWorkTab(workID string, label string) *WorkTab {
 		label = workID
 	}
 	return &WorkTab{
-		ID:               workID,
-		Type:             WorkTabWork,
-		Label:            label,
-		WorkID:           workID,
-		ActiveSubSession: SubSessionAgent,
+		ID:     workID,
+		Type:   WorkTabWork,
+		Label:  label,
+		WorkID: workID,
 	}
 }
 

--- a/internal/work/orchestrator.go
+++ b/internal/work/orchestrator.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sargehq/sarge/internal/bridge"
 	"github.com/sargehq/sarge/internal/db"
 	"github.com/sargehq/sarge/internal/logging"
 	"github.com/sargehq/sarge/internal/project"
@@ -58,8 +57,7 @@ type OrchestratorManager interface {
 // It holds the database reference needed for orchestrator heartbeat checking.
 type DefaultOrchestratorManager struct {
 	database   *db.DB
-	bridge     *bridge.Bridge           // Optional: headless RPC sessions (sequencer)
-	ptyManager *ptysession.Manager      // PTY sessions for interactive use (plan/agent/console)
+	ptyManager *ptysession.Manager // PTY sessions for interactive use (plan/agent/console/task)
 	projCfg    *project.Config
 	beansPath  string // Path to beans directory (needed for plan prompts)
 }
@@ -72,13 +70,10 @@ func NewOrchestratorManager(database *db.DB, cfg *project.Config) OrchestratorMa
 	}
 }
 
-// NewOrchestratorManagerWithBridge creates a DefaultOrchestratorManager that routes
-// plan and agent sessions through the given bridge (pi RPC) for headless use,
-// and uses PTY sessions for interactive use.
-func NewOrchestratorManagerWithBridge(database *db.DB, cfg *project.Config, b *bridge.Bridge, ptyMgr *ptysession.Manager, beansPath string) OrchestratorManager {
+// NewOrchestratorManagerWithPTY creates a DefaultOrchestratorManager with PTY session support.
+func NewOrchestratorManagerWithPTY(database *db.DB, cfg *project.Config, ptyMgr *ptysession.Manager, beansPath string) OrchestratorManager {
 	return &DefaultOrchestratorManager{
 		database:   database,
-		bridge:     b,
 		ptyManager: ptyMgr,
 		projCfg:    cfg,
 		beansPath:  beansPath,
@@ -113,18 +108,6 @@ func (m *DefaultOrchestratorManager) TerminateWorkTabs(ctx context.Context, work
 			if strings.Contains(id, workID) {
 				if err := m.ptyManager.Kill(id); err == nil {
 					fmt.Fprintf(w, "  Killed PTY session: %s\n", id)
-				}
-			}
-		}
-	}
-
-	// Kill bridge sessions belonging to this work
-	if m.bridge != nil {
-		sessions := m.bridge.ListSessions()
-		for id := range sessions {
-			if strings.Contains(id, workID) {
-				if err := m.bridge.KillSession(id); err == nil {
-					fmt.Fprintf(w, "  Killed bridge session: %s\n", id)
 				}
 			}
 		}
@@ -224,22 +207,6 @@ func (m *DefaultOrchestratorManager) ListWorkSessions(ctx context.Context, workI
 				TabName:     id,
 				Type:        sessionType,
 				DisplayName: fmt.Sprintf("%s (%s) [%s]", sessionType, id, state),
-			})
-		}
-	}
-
-	// Include bridge sessions (headless tasks from sequencer)
-	if m.bridge != nil {
-		bridgeSessions := m.bridge.ListSessions()
-		for id, state := range bridgeSessions {
-			if !strings.Contains(id, workID) {
-				continue
-			}
-			result = append(result, WorkSession{
-				Name:        id,
-				TabName:     id,
-				Type:        "task",
-				DisplayName: fmt.Sprintf("task (%s) [%s]", id, state),
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a chain of bugs preventing auto works from running and being visible in the TUI.

### Bug 1: Auto work never started after worktree creation
The auto workflow setup code was inside `executeTask()` in the sequencer — unreachable for fresh work with no tasks. Moved to `tryStartNextTask()` where the sequencer polls for ready tasks.

### Bug 2: Sequencer hangs after task completion
`waitForCompletion()` called `session.Wait()` after `EventAgentEnd`, blocking on process exit. In RPC mode, pi stays alive waiting for the next prompt, so the goroutine hung forever. This prevented post-task handling (e.g., creating implement tasks after estimation).

### Bug 3: Tasks invisible in TUI (bridge → PTY migration)
The sequencer spawned pi in headless RPC mode via bridge sessions, which were invisible in the TUI. Replaced with PTY sessions that use `InitialPrompt` — tasks now appear in the TUI session viewer. Removed all bridge dependencies from the TUI, orchestrator manager, and session picker.

### Feature: Dynamic sub-tabs for work sessions
Replaced the fixed agent/console/plan sub-session model with dynamic sub-tabs discovered from the PTY manager. Task sessions appear as numbered sub-tabs (`ctrl+1..9` to switch). The active task session auto-displays when focusing a work tab.

### Fixes
- `main-zkqk` — Auto work not started after worktree creation
- `main-14yj` — Sequencer uses headless bridge sessions

### Commits
- fix: start auto workflow after worktree creation in sequencer
- fix: sequencer hangs after task completion in RPC mode
- fix: use PTY sessions in sequencer so tasks are visible in TUI
- fix: TUI attach-terminal gate checks PTY sessions not bridge sessions
- refactor: remove bridge dependency from TUI and orchestrator manager
- fix: auto-display active task session when switching to work tab
- feat: dynamic sub-tabs for work sessions in TUI
- fix: show session panel when work is focused from any tab