### PR TITLE
fix: TUI panel width overflow and PTY session not terminating on task completion

### DIFF
--- a/.beans/main-1mhq--pty-session-not-terminated-when-sarge-complete-run.md
+++ b/.beans/main-1mhq--pty-session-not-terminated-when-sarge-complete-run.md
@@ -1,0 +1,33 @@
+---
+# main-1mhq
+title: PTY session not terminated when sarge complete runs in TUI
+status: completed
+type: bug
+priority: normal
+created_at: 2026-03-12T18:21:49Z
+updated_at: 2026-03-12T18:22:20Z
+---
+
+When the pi agent calls `sarge complete` during TUI task execution, it marks the task as completed in the DB but the PTY session keeps running. The old `runner.MonitorAgent` watched for DB task status changes and sent SIGTERM, but the sequencer's `executeTask()` only waits for process exit or context cancellation.
+
+## Root Cause
+In `internal/taskseq/sequencer.go`, `executeTask()` spawns a PTY session and then does:
+```go
+select {
+case <-exited:
+case <-taskCtx.Done():
+}
+```
+No case watches for task status changes in the DB.
+
+## Fix
+Add a DB watcher goroutine that polls/watches for task completion and kills the PTY session when detected. Use the existing tracking watcher infrastructure.
+
+## Todo
+- [x] Add DB status monitoring in executeTask select loop
+- [x] Kill PTY session when task status changes to completed/failed
+- [x] Verify build compiles
+
+## Summary of Changes
+
+Added a DB status monitoring goroutine in the sequencer's `executeTask()`. It polls every 2 seconds for task status changes. When the task is marked completed/failed (by `sarge complete`), it gives the agent 5 seconds to exit gracefully, then kills the PTY session. This matches the behavior of the old `runner.MonitorAgent` but adapted for the PTY-based sequencer.

--- a/.beans/main-58eo--work-panel-content-width-calculation-off-by-2-sepa.md
+++ b/.beans/main-58eo--work-panel-content-width-calculation-off-by-2-sepa.md
@@ -1,0 +1,36 @@
+---
+# main-58eo
+title: Work panel content width calculation off by 2 — separators overflow and left box too short
+status: completed
+type: bug
+priority: normal
+created_at: 2026-03-12T18:14:38Z
+updated_at: 2026-03-12T18:15:23Z
+---
+
+The work overview, summary, and task sub-panels use `contentWidth := panelWidth - 2` which only accounts for padding (Padding(0,1) = 2 chars). But lipgloss v2's `.Width()` includes both border AND padding, so content wraps at `Width - 4` (border 2 + padding 2). The IssuesPanel correctly uses `p.width - 4`.
+
+This causes:
+1. Right panel (Details): separator lines (strings.Repeat("─", contentWidth)) are 2 chars too wide, wrapping to next line
+2. Left panel (Work): same issue with separator, eating vertical space and making the box appear too short
+
+## Files to fix
+- `internal/tui/tui_panel_work_overview.go`: line 249 `contentWidth := panelWidth - 2` → `panelWidth - 4`
+- `internal/tui/tui_panel_work_summary.go`: line 119 `contentWidth := panelWidth - 2` → `panelWidth - 4`, viewport SetWidth
+- `internal/tui/tui_panel_work_task.go`: lines 145,199 `contentWidth := panelWidth - 2` → `panelWidth - 4`, viewport SetWidth
+
+## Todo
+- [x] Fix contentWidth in tui_panel_work_overview.go
+- [x] Fix contentWidth in tui_panel_work_summary.go  
+- [x] Fix contentWidth in tui_panel_work_task.go
+- [x] Fix viewport SetWidth in summary and task panels
+- [x] Verify build compiles
+
+## Summary of Changes
+
+Fixed content width calculation in three work panel files. All used `panelWidth - 2` (only accounting for padding), but lipgloss v2's `.Width()` includes both border (2 chars) and padding (2 chars), so the correct offset is `panelWidth - 4`. The IssuesPanel already had the correct calculation (`p.width - 4`).
+
+### Files changed:
+- `internal/tui/tui_panel_work_overview.go`: contentWidth fix (line 249)
+- `internal/tui/tui_panel_work_summary.go`: contentWidth fix + viewport SetWidth fix
+- `internal/tui/tui_panel_work_task.go`: contentWidth fix (2 occurrences) + viewport SetWidth fix

--- a/internal/taskseq/sequencer.go
+++ b/internal/taskseq/sequencer.go
@@ -279,7 +279,7 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 		return
 	}
 
-	// Wait for pi process to exit or timeout
+	// Wait for pi process to exit, timeout, or task completion via DB
 	startTime := time.Now()
 	exited := make(chan struct{})
 	go func() {
@@ -287,9 +287,46 @@ func (s *Sequencer) executeTask(ctx context.Context, w *db.Work, t *db.Task) {
 		close(exited)
 	}()
 
+	// Monitor DB for task completion (e.g. when agent calls "sarge complete").
+	// Poll every 2s; when the task is marked completed/failed, signal to kill the session.
+	taskDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-exited:
+				return
+			case <-taskCtx.Done():
+				return
+			case <-ticker.C:
+				updated, err := s.proj.DB.GetTask(taskCtx, t.ID)
+				if err != nil {
+					continue
+				}
+				if updated != nil && (updated.Status == db.StatusCompleted || updated.Status == db.StatusFailed) {
+					close(taskDone)
+					return
+				}
+			}
+		}
+	}()
+
 	select {
 	case <-exited:
 		// Process exited normally
+	case <-taskDone:
+		// Task was marked completed/failed in DB (e.g. by "sarge complete")
+		// Give the agent a moment to clean up, then kill the session.
+		logging.Info("Task completed in DB, terminating PTY session", "task_id", t.ID)
+		select {
+		case <-exited:
+			// Agent exited on its own
+		case <-time.After(5 * time.Second):
+			logging.Info("Agent didn't exit after task completion, killing session", "task_id", t.ID)
+			_ = s.ptyManager.Kill(sessionID)
+			<-exited
+		}
 	case <-taskCtx.Done():
 		if taskCtx.Err() == context.DeadlineExceeded {
 			logging.Warn("Task timed out", "task_id", t.ID, "timeout", timeout)

--- a/internal/tui/tui_panel_work_overview.go
+++ b/internal/tui/tui_panel_work_overview.go
@@ -245,8 +245,8 @@ func (p *WorkOverviewPanel) Render(panelHeight, panelWidth int) string {
 		return content.String()
 	}
 
-	// Account for padding (tuiPanelStyle has Padding(0, 1) = 2 chars total)
-	contentWidth := panelWidth - 2
+	// Account for border + padding (tuiPanelStyle has Border + Padding(0, 1) = 4 chars total)
+	contentWidth := panelWidth - 4
 
 	// Work header (1 line)
 	workHeader := fmt.Sprintf("%s %s", statusIcon(p.focusedWork.Work.Status), p.focusedWork.Work.ID)

--- a/internal/tui/tui_panel_work_summary.go
+++ b/internal/tui/tui_panel_work_summary.go
@@ -52,8 +52,8 @@ func (p *WorkSummaryPanel) SetSize(width, height int) {
 	// Calculate available lines for content (minus border and title)
 	visibleLines := max(height-3, 1)
 
-	// Set viewport size accounting for padding (2 chars total)
-	p.viewport.SetWidth(width - 2)
+	// Set viewport size accounting for border + padding (4 chars total)
+	p.viewport.SetWidth(width - 4)
 	p.viewport.SetHeight(visibleLines)
 }
 
@@ -115,8 +115,8 @@ func (p *WorkSummaryPanel) renderFullContent(panelWidth int) string {
 		return content.String()
 	}
 
-	// Account for padding (tuiPanelStyle has Padding(0, 1) = 2 chars total)
-	contentWidth := panelWidth - 2
+	// Account for border + padding (tuiPanelStyle has Border + Padding(0, 1) = 4 chars total)
+	contentWidth := panelWidth - 4
 
 	// == Work Overview Section ==
 	overviewStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))

--- a/internal/tui/tui_panel_work_task.go
+++ b/internal/tui/tui_panel_work_task.go
@@ -53,8 +53,8 @@ func (p *WorkTaskPanel) SetSize(width, height int) {
 	// Calculate available lines for content (minus border and title)
 	visibleLines := max(height-3, 1)
 
-	// Set viewport size accounting for padding (2 chars total)
-	p.viewport.SetWidth(width - 2)
+	// Set viewport size accounting for border + padding (4 chars total)
+	p.viewport.SetWidth(width - 4)
 	p.viewport.SetHeight(visibleLines)
 }
 
@@ -141,8 +141,8 @@ func (p *WorkTaskPanel) renderTaskDetails(panelWidth int) string {
 	var content strings.Builder
 	task := p.selectedTask
 
-	// Account for padding (tuiPanelStyle has Padding(0, 1) = 2 chars total)
-	contentWidth := panelWidth - 2
+	// Account for border + padding (tuiPanelStyle has Border + Padding(0, 1) = 4 chars total)
+	contentWidth := panelWidth - 4
 
 	fmt.Fprintf(&content, "ID: %s\n", task.Task.ID)
 	fmt.Fprintf(&content, "Type: %s\n", task.Task.TaskType)
@@ -195,8 +195,8 @@ func (p *WorkTaskPanel) renderUnassignedBeanDetails(panelWidth int) string {
 	var content strings.Builder
 	bean := p.selectedBean
 
-	// Account for padding (tuiPanelStyle has Padding(0, 1) = 2 chars total)
-	contentWidth := panelWidth - 2
+	// Account for border + padding (tuiPanelStyle has Border + Padding(0, 1) = 4 chars total)
+	contentWidth := panelWidth - 4
 
 	// Header with warning style and action hint
 	warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))


### PR DESCRIPTION
## Changes

### 1. Work panel content width off by 2 (main-58eo)
The work overview, summary, and task sub-panels used `panelWidth - 2` for content width, only accounting for padding. But lipgloss v2's `.Width()` includes both border (2) and padding (2), so the correct offset is `panelWidth - 4`. The IssuesPanel already had the correct calculation.

**Symptoms:**
- Right panel (Details): separator lines wrapped to the next line, breaking the layout
- Left panel (Work): wrapped separators consumed vertical space, making the box too short

**Files:** `tui_panel_work_overview.go`, `tui_panel_work_summary.go`, `tui_panel_work_task.go`

### 2. PTY session not terminated when sarge complete runs (main-1mhq)
When the pi agent called `sarge complete` during TUI task execution, the task was marked completed in the DB but the PTY session kept running. The sequencer's `executeTask()` only waited for process exit or context cancellation — it never checked the DB for status changes.

**Fix:** Added a DB polling goroutine that checks task status every 2s. When the task is marked completed/failed, it gives the agent 5s to exit gracefully, then kills the PTY session.

**File:** `internal/taskseq/sequencer.go`