### PR TITLE
feat: ctrl+key TUI hotkeys with pi session passthrough

### DIFF
--- a/.beans/main-jybl--fix-tui-hotkeys-use-alt-instead-of-ctrl-to-avoid-p.md
+++ b/.beans/main-jybl--fix-tui-hotkeys-use-alt-instead-of-ctrl-to-avoid-p.md
@@ -1,11 +1,11 @@
 ---
 # main-jybl
 title: 'Fix TUI hotkeys: use alt+ instead of ctrl+ to avoid pi hotkey conflicts'
-status: completed
+status: scrapped
 type: bug
 priority: normal
 created_at: 2026-03-13T12:16:15Z
-updated_at: 2026-03-13T12:19:30Z
+updated_at: 2026-03-13T13:19:03Z
 ---
 
 The ctrl+ hotkeys conflict with pi session hotkeys (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k). Need to use alt+letter instead since pi only uses alt+enter and alt+up.
@@ -24,3 +24,6 @@ The ctrl+ hotkeys conflict with pi session hotkeys (ctrl+c, ctrl+d, ctrl+z, ctrl
 
 ## Summary of Changes
 Changed all TUI hotkeys from ctrl+ to alt+ to avoid conflicts with pi session hotkeys (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k). Pi only uses alt+enter and alt+up, so all alt+letter combos are free for TUI use.
+
+## Reasons for Scrapping
+alt/option key on macOS is treated as a compose/dead key, not as Alt modifier. ModAlt is never set. alt+key is completely unusable.

--- a/.beans/main-jybl--fix-tui-hotkeys-use-alt-instead-of-ctrl-to-avoid-p.md
+++ b/.beans/main-jybl--fix-tui-hotkeys-use-alt-instead-of-ctrl-to-avoid-p.md
@@ -1,0 +1,26 @@
+---
+# main-jybl
+title: 'Fix TUI hotkeys: use alt+ instead of ctrl+ to avoid pi hotkey conflicts'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-03-13T12:16:15Z
+updated_at: 2026-03-13T12:19:30Z
+---
+
+The ctrl+ hotkeys conflict with pi session hotkeys (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k). Need to use alt+letter instead since pi only uses alt+enter and alt+up.
+
+## Todo
+- [x] Change all ctrl+key hotkeys to alt+key in tui_plan.go
+- [x] Change all ctrl+key hotkeys to alt+key in tui_panel_work_details.go
+- [x] Update session interception to catch alt+key instead of ctrl+key
+- [x] Update status bar labels in tui_panel_status.go (⌥ prefix)
+- [x] Update help screen in tui_plan_render.go
+- [x] Update work task panel hint in tui_panel_work_task.go
+- [x] Update mouse click handlers to send ModAlt
+- [x] Update tui_root.go quit key to alt+q
+- [x] Keep ctrl+shift+1-9 for sub-sessions (no pi conflict)
+- [x] Build and test pass
+
+## Summary of Changes
+Changed all TUI hotkeys from ctrl+ to alt+ to avoid conflicts with pi session hotkeys (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k). Pi only uses alt+enter and alt+up, so all alt+letter combos are free for TUI use.

--- a/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
+++ b/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
@@ -1,11 +1,11 @@
 ---
 # main-kmwe
 title: Change TUI hotkeys to ctrl-/cmd- prefixes for pi session compatibility
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-03-13T04:23:26Z
-updated_at: 2026-03-13T13:19:11Z
+updated_at: 2026-03-13T13:19:24Z
 ---
 
 Pi sessions need complete keyboard control, so all TUI hotkeys must use ctrl- or cmd- modifiers instead of bare letters.
@@ -31,3 +31,6 @@ Changed all TUI action hotkeys from bare letters to ctrl+ prefixed keys so pi se
 
 ## Revised approach
 Use ctrl+key for all TUI hotkeys. When a pi session is focused, only ESC exits — all other keys (including ctrl+key) go to the session. This gives pi complete control when active, while ctrl+key works everywhere else.
+
+## Summary of Changes
+All TUI action hotkeys now use ctrl+key (detected via msg.Mod/msg.Code helpers). When a pi session panel is focused, only ESC exits — all other keys go to the PTY, giving pi complete control. Verified with keytest that ctrl+key produces ModCtrl=true reliably on macOS with Kitty protocol.

--- a/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
+++ b/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
@@ -1,11 +1,11 @@
 ---
 # main-kmwe
 title: Change TUI hotkeys to ctrl-/cmd- prefixes for pi session compatibility
-status: completed
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-03-13T04:23:26Z
-updated_at: 2026-03-13T04:31:33Z
+updated_at: 2026-03-13T13:19:11Z
 ---
 
 Pi sessions need complete keyboard control, so all TUI hotkeys must use ctrl- or cmd- modifiers instead of bare letters.
@@ -28,3 +28,6 @@ Changed all TUI action hotkeys from bare letters to ctrl+ prefixed keys so pi se
 - Work actions: ctrl+t (term), ctrl+c (chat), ctrl+i (IDE), ctrl+r (run), ctrl+o (orch), ctrl+v (review), ctrl+f (feedback), ctrl+g (session)
 - Other: ctrl+s (sort), ctrl+z (maximize), ctrl+q (quit), ctrl+shift+e (editor), ctrl+shift+m (PR import), ctrl+shift+a (add to work), ctrl+shift+1-9 (sub-sessions)
 - Unchanged: j/k/arrows (nav), tab (cycle), 1-9 (tabs), space (select), esc, O/C/R/V/L (filters), / (search), ? (help), [ ] (resize)
+
+## Revised approach
+Use ctrl+key for all TUI hotkeys. When a pi session is focused, only ESC exits — all other keys (including ctrl+key) go to the session. This gives pi complete control when active, while ctrl+key works everywhere else.

--- a/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
+++ b/.beans/main-kmwe--change-tui-hotkeys-to-ctrl-cmd-prefixes-for-pi-ses.md
@@ -1,0 +1,30 @@
+---
+# main-kmwe
+title: Change TUI hotkeys to ctrl-/cmd- prefixes for pi session compatibility
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-13T04:23:26Z
+updated_at: 2026-03-13T04:31:33Z
+---
+
+Pi sessions need complete keyboard control, so all TUI hotkeys must use ctrl- or cmd- modifiers instead of bare letters.
+
+## Todo
+- [x] Update handleKeyPress in tui_plan.go to use ctrl- prefixed keys
+- [x] Update status bar labels in tui_panel_status.go
+- [x] Update work details panel hotkeys in tui_panel_work_task.go and tui_panel_work_details.go
+- [x] Update help screen text in tui_plan_render.go
+- [x] Intercept ctrl+key combos in session handler before PTY forwarding
+- [x] Update mouse click handlers to send ctrl+key
+- [x] Update tui_root.go quit key
+- [x] Build and test pass
+
+## Summary of Changes
+Changed all TUI action hotkeys from bare letters to ctrl+ prefixed keys so pi sessions get complete keyboard control. Bare keys in a session panel are forwarded to the PTY; ctrl+key combos are intercepted by the TUI regardless of active panel.
+
+### Key mapping:
+- Issue actions: ctrl+n (new), ctrl+e (edit), ctrl+a (child), ctrl+x (close), ctrl+d (delete), ctrl+w (work), ctrl+p (plan)
+- Work actions: ctrl+t (term), ctrl+c (chat), ctrl+i (IDE), ctrl+r (run), ctrl+o (orch), ctrl+v (review), ctrl+f (feedback), ctrl+g (session)
+- Other: ctrl+s (sort), ctrl+z (maximize), ctrl+q (quit), ctrl+shift+e (editor), ctrl+shift+m (PR import), ctrl+shift+a (add to work), ctrl+shift+1-9 (sub-sessions)
+- Unchanged: j/k/arrows (nav), tab (cycle), 1-9 (tabs), space (select), esc, O/C/R/V/L (filters), / (search), ? (help), [ ] (resize)

--- a/.beans/main-sc3w--fix-altkey-matching-use-msgmodcode-instead-of-msgs.md
+++ b/.beans/main-sc3w--fix-altkey-matching-use-msgmodcode-instead-of-msgs.md
@@ -1,11 +1,11 @@
 ---
 # main-sc3w
 title: 'Fix alt+key matching: use msg.Mod/Code instead of msg.String()'
-status: completed
+status: scrapped
 type: bug
 priority: normal
 created_at: 2026-03-13T12:24:29Z
-updated_at: 2026-03-13T12:28:11Z
+updated_at: 2026-03-13T13:19:07Z
 ---
 
 msg.String() returns the Text field which doesn't include modifier info for alt+key. Need to check msg.Mod&ModAlt and msg.Code directly.
@@ -20,3 +20,6 @@ msg.String() returns the Text field which doesn't include modifier info for alt+
 
 ## Summary of Changes
 msg.String() returns the Text field which doesn't include modifier info. For alt+n on macOS, String() might return 'ñ' or just 'n' — never 'alt+n'. Fixed by checking msg.Mod & msg.Code directly via helper functions.
+
+## Reasons for Scrapping
+alt+key approach was fundamentally broken on macOS. Switched to ctrl+key with session-blocks-all-except-ESC approach instead.

--- a/.beans/main-sc3w--fix-altkey-matching-use-msgmodcode-instead-of-msgs.md
+++ b/.beans/main-sc3w--fix-altkey-matching-use-msgmodcode-instead-of-msgs.md
@@ -1,0 +1,22 @@
+---
+# main-sc3w
+title: 'Fix alt+key matching: use msg.Mod/Code instead of msg.String()'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-03-13T12:24:29Z
+updated_at: 2026-03-13T12:28:11Z
+---
+
+msg.String() returns the Text field which doesn't include modifier info for alt+key. Need to check msg.Mod&ModAlt and msg.Code directly.
+
+## Todo
+- [x] Add altKey() and altShiftKey() helpers in tui_shared.go
+- [x] Refactor tui_plan.go: extracted handleAltKey() and handleAltShiftKey() methods
+- [x] Refactor tui_panel_work_details.go: extracted handleAltAction() method
+- [x] Session interception uses altKey()/altShiftKey() helpers
+- [x] tui_root.go uses altKey() for quit
+- [x] Build and test pass
+
+## Summary of Changes
+msg.String() returns the Text field which doesn't include modifier info. For alt+n on macOS, String() might return 'ñ' or just 'n' — never 'alt+n'. Fixed by checking msg.Mod & msg.Code directly via helper functions.

--- a/internal/tui/tui_panel_status.go
+++ b/internal/tui/tui_panel_status.go
@@ -222,41 +222,39 @@ func (s *StatusBar) Render() string {
 // renderIssuesCommands returns commands for the issues panel (no work focused)
 func (s *StatusBar) renderIssuesCommands() (string, string) {
 	// Commands on the left with hover effects - wrap each with zone.Mark
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("[x]close", s.hoveredButton == "x"))
-	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("[d]el", s.hoveredButton == "d"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("[w]ork", s.hoveredButton == "w"))
-	OButton := zone.Mark(s.zonePrefix+"O", styleButtonWithHover("[O]pen", s.hoveredButton == "O"))
-	CButton := zone.Mark(s.zonePrefix+"C", styleButtonWithHover("[C]losed", s.hoveredButton == "C"))
-	RButton := zone.Mark(s.zonePrefix+"R", styleButtonWithHover("[R]eady", s.hoveredButton == "R"))
+	// All action keys use ctrl+ prefix so pi sessions get complete keyboard control
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
+	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("^[d]el", s.hoveredButton == "d"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
-	commands := nButton + " " + eButton + " " + aButton + " " + xButton + " " + dButton + " " + wButton + " " + OButton + " " + CButton + " " + RButton + " " + helpButton
-	commandsPlain := "[n]ew [e]dit [a]child [x]close [d]el [w]ork [O]pen [C]losed [R]eady [?]help"
+	commands := nButton + " " + eButton + " " + aButton + " " + xButton + " " + dButton + " " + wButton + " " + helpButton
+	commandsPlain := "^[n]ew ^[e]dit ^[a]child ^[x]close ^[d]el ^[w]ork [?]help"
 
 	return commands, commandsPlain
 }
 
 // renderWorkFocusedCommands returns merged commands: work actions + non-conflicting issue actions
 func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
-	// Work action keys
-	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("[t]erm", s.hoveredButton == "t"))
-	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("[c]hat", s.hoveredButton == "c"))
-	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("[i]DE", s.hoveredButton == "i"))
-	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("[r]un", s.hoveredButton == "r"))
-	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("[o]rch", s.hoveredButton == "o"))
-	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("[v]review", s.hoveredButton == "v"))
-	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("[p]r", s.hoveredButton == "p"))
-	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("[f]eedback", s.hoveredButton == "f"))
+	// Work action keys - all use ctrl+ prefix
+	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("^[t]erm", s.hoveredButton == "t"))
+	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("^[c]hat", s.hoveredButton == "c"))
+	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("^[i]DE", s.hoveredButton == "i"))
+	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("^[r]un", s.hoveredButton == "r"))
+	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("^[o]rch", s.hoveredButton == "o"))
+	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("^[v]review", s.hoveredButton == "v"))
+	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("^[p]r", s.hoveredButton == "p"))
+	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("^[f]eedback", s.hoveredButton == "f"))
 
-	// 'd' is panel-aware: shows [d]estroy when work panel is focused, [d]el when issues panel is focused
-	dLabel := "[d]estroy"
-	dLabelPlain := "[d]estroy"
+	// ctrl+d is panel-aware: shows ^[d]estroy when work panel is focused, ^[d]el when issues panel is focused
+	dLabel := "^[d]estroy"
+	dLabelPlain := "^[d]estroy"
 	if s.getActivePanel != nil && s.getActivePanel() == PanelLeft {
-		dLabel = "[d]el"
-		dLabelPlain = "[d]el"
+		dLabel = "^[d]el"
+		dLabelPlain = "^[d]el"
 	}
 	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover(dLabel, s.hoveredButton == "d"))
 
@@ -264,15 +262,15 @@ func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
 	sep := tuiDimStyle.Render("|")
 
 	// Non-conflicting issue actions
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("[x]close", s.hoveredButton == "x"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("[w]ork", s.hoveredButton == "w"))
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
 	commands := tButton + " " + cButton + " " + iButton + " " + rButton + " " + oButton + " " + vButton + " " + pButton + " " + fButton + " " + dButton + " " + sep + " " + nButton + " " + eButton + " " + aButton + " " + xButton + " " + wButton + " " + helpButton
-	commandsPlain := "[t]erm [c]hat [i]DE [r]un [o]rch [v]review [p]r [f]eedback " + dLabelPlain + " | [n]ew [e]dit [a]child [x]close [w]ork [?]help"
+	commandsPlain := "^[t]erm ^[c]hat ^[i]DE ^[r]un ^[o]rch ^[v]review ^[p]r ^[f]eedback " + dLabelPlain + " | ^[n]ew ^[e]dit ^[a]child ^[x]close ^[w]ork [?]help"
 
 	return commands, commandsPlain
 }

--- a/internal/tui/tui_panel_status.go
+++ b/internal/tui/tui_panel_status.go
@@ -222,39 +222,39 @@ func (s *StatusBar) Render() string {
 // renderIssuesCommands returns commands for the issues panel (no work focused)
 func (s *StatusBar) renderIssuesCommands() (string, string) {
 	// Commands on the left with hover effects - wrap each with zone.Mark
-	// All action keys use ctrl+ prefix so pi sessions get complete keyboard control
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
-	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("^[d]el", s.hoveredButton == "d"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
+	// All action keys use alt+ prefix so pi sessions get complete keyboard control
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("⌥[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("⌥[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("⌥[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("⌥[x]close", s.hoveredButton == "x"))
+	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("⌥[d]el", s.hoveredButton == "d"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("⌥[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
 	commands := nButton + " " + eButton + " " + aButton + " " + xButton + " " + dButton + " " + wButton + " " + helpButton
-	commandsPlain := "^[n]ew ^[e]dit ^[a]child ^[x]close ^[d]el ^[w]ork [?]help"
+	commandsPlain := "⌥[n]ew ⌥[e]dit ⌥[a]child ⌥[x]close ⌥[d]el ⌥[w]ork [?]help"
 
 	return commands, commandsPlain
 }
 
 // renderWorkFocusedCommands returns merged commands: work actions + non-conflicting issue actions
 func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
-	// Work action keys - all use ctrl+ prefix
-	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("^[t]erm", s.hoveredButton == "t"))
-	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("^[c]hat", s.hoveredButton == "c"))
-	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("^[i]DE", s.hoveredButton == "i"))
-	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("^[r]un", s.hoveredButton == "r"))
-	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("^[o]rch", s.hoveredButton == "o"))
-	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("^[v]review", s.hoveredButton == "v"))
-	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("^[p]r", s.hoveredButton == "p"))
-	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("^[f]eedback", s.hoveredButton == "f"))
+	// Work action keys - all use alt+ prefix
+	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("⌥[t]erm", s.hoveredButton == "t"))
+	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("⌥[c]hat", s.hoveredButton == "c"))
+	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("⌥[i]DE", s.hoveredButton == "i"))
+	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("⌥[r]un", s.hoveredButton == "r"))
+	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("⌥[o]rch", s.hoveredButton == "o"))
+	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("⌥[v]review", s.hoveredButton == "v"))
+	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("⌥[p]r", s.hoveredButton == "p"))
+	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("⌥[f]eedback", s.hoveredButton == "f"))
 
-	// ctrl+d is panel-aware: shows ^[d]estroy when work panel is focused, ^[d]el when issues panel is focused
-	dLabel := "^[d]estroy"
-	dLabelPlain := "^[d]estroy"
+	// alt+d is panel-aware: shows ⌥[d]estroy when work panel is focused, ⌥[d]el when issues panel is focused
+	dLabel := "⌥[d]estroy"
+	dLabelPlain := "⌥[d]estroy"
 	if s.getActivePanel != nil && s.getActivePanel() == PanelLeft {
-		dLabel = "^[d]el"
-		dLabelPlain = "^[d]el"
+		dLabel = "⌥[d]el"
+		dLabelPlain = "⌥[d]el"
 	}
 	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover(dLabel, s.hoveredButton == "d"))
 
@@ -262,15 +262,15 @@ func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
 	sep := tuiDimStyle.Render("|")
 
 	// Non-conflicting issue actions
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("⌥[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("⌥[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("⌥[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("⌥[x]close", s.hoveredButton == "x"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("⌥[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
 	commands := tButton + " " + cButton + " " + iButton + " " + rButton + " " + oButton + " " + vButton + " " + pButton + " " + fButton + " " + dButton + " " + sep + " " + nButton + " " + eButton + " " + aButton + " " + xButton + " " + wButton + " " + helpButton
-	commandsPlain := "^[t]erm ^[c]hat ^[i]DE ^[r]un ^[o]rch ^[v]review ^[p]r ^[f]eedback " + dLabelPlain + " | ^[n]ew ^[e]dit ^[a]child ^[x]close ^[w]ork [?]help"
+	commandsPlain := "⌥[t]erm ⌥[c]hat ⌥[i]DE ⌥[r]un ⌥[o]rch ⌥[v]review ⌥[p]r ⌥[f]eedback " + dLabelPlain + " | ⌥[n]ew ⌥[e]dit ⌥[a]child ⌥[x]close ⌥[w]ork [?]help"
 
 	return commands, commandsPlain
 }

--- a/internal/tui/tui_panel_status.go
+++ b/internal/tui/tui_panel_status.go
@@ -222,39 +222,39 @@ func (s *StatusBar) Render() string {
 // renderIssuesCommands returns commands for the issues panel (no work focused)
 func (s *StatusBar) renderIssuesCommands() (string, string) {
 	// Commands on the left with hover effects - wrap each with zone.Mark
-	// All action keys use alt+ prefix so pi sessions get complete keyboard control
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("⌥[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("⌥[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("⌥[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("⌥[x]close", s.hoveredButton == "x"))
-	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("⌥[d]el", s.hoveredButton == "d"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("⌥[w]ork", s.hoveredButton == "w"))
+	// All action keys use ctrl+ prefix; pi sessions get complete control (only ESC exits)
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
+	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover("^[d]el", s.hoveredButton == "d"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
 	commands := nButton + " " + eButton + " " + aButton + " " + xButton + " " + dButton + " " + wButton + " " + helpButton
-	commandsPlain := "⌥[n]ew ⌥[e]dit ⌥[a]child ⌥[x]close ⌥[d]el ⌥[w]ork [?]help"
+	commandsPlain := "^[n]ew ^[e]dit ^[a]child ^[x]close ^[d]el ^[w]ork [?]help"
 
 	return commands, commandsPlain
 }
 
 // renderWorkFocusedCommands returns merged commands: work actions + non-conflicting issue actions
 func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
-	// Work action keys - all use alt+ prefix
-	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("⌥[t]erm", s.hoveredButton == "t"))
-	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("⌥[c]hat", s.hoveredButton == "c"))
-	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("⌥[i]DE", s.hoveredButton == "i"))
-	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("⌥[r]un", s.hoveredButton == "r"))
-	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("⌥[o]rch", s.hoveredButton == "o"))
-	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("⌥[v]review", s.hoveredButton == "v"))
-	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("⌥[p]r", s.hoveredButton == "p"))
-	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("⌥[f]eedback", s.hoveredButton == "f"))
+	// Work action keys - all use ctrl+ prefix
+	tButton := zone.Mark(s.zonePrefix+"t", styleButtonWithHover("^[t]erm", s.hoveredButton == "t"))
+	cButton := zone.Mark(s.zonePrefix+"c", styleButtonWithHover("^[c]hat", s.hoveredButton == "c"))
+	iButton := zone.Mark(s.zonePrefix+"i", styleButtonWithHover("^[i]DE", s.hoveredButton == "i"))
+	rButton := zone.Mark(s.zonePrefix+"r", styleButtonWithHover("^[r]un", s.hoveredButton == "r"))
+	oButton := zone.Mark(s.zonePrefix+"o", styleButtonWithHover("^[o]rch", s.hoveredButton == "o"))
+	vButton := zone.Mark(s.zonePrefix+"v", styleButtonWithHover("^[v]review", s.hoveredButton == "v"))
+	pButton := zone.Mark(s.zonePrefix+"p", styleButtonWithHover("^[p]r", s.hoveredButton == "p"))
+	fButton := zone.Mark(s.zonePrefix+"f", styleButtonWithHover("^[f]eedback", s.hoveredButton == "f"))
 
-	// alt+d is panel-aware: shows ⌥[d]estroy when work panel is focused, ⌥[d]el when issues panel is focused
-	dLabel := "⌥[d]estroy"
-	dLabelPlain := "⌥[d]estroy"
+	// ctrl+d is panel-aware: shows ^[d]estroy when work panel is focused, ^[d]el when issues panel is focused
+	dLabel := "^[d]estroy"
+	dLabelPlain := "^[d]estroy"
 	if s.getActivePanel != nil && s.getActivePanel() == PanelLeft {
-		dLabel = "⌥[d]el"
-		dLabelPlain = "⌥[d]el"
+		dLabel = "^[d]el"
+		dLabelPlain = "^[d]el"
 	}
 	dButton := zone.Mark(s.zonePrefix+"d", styleButtonWithHover(dLabel, s.hoveredButton == "d"))
 
@@ -262,15 +262,15 @@ func (s *StatusBar) renderWorkFocusedCommands() (string, string) {
 	sep := tuiDimStyle.Render("|")
 
 	// Non-conflicting issue actions
-	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("⌥[n]ew", s.hoveredButton == "n"))
-	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("⌥[e]dit", s.hoveredButton == "e"))
-	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("⌥[a]child", s.hoveredButton == "a"))
-	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("⌥[x]close", s.hoveredButton == "x"))
-	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("⌥[w]ork", s.hoveredButton == "w"))
+	nButton := zone.Mark(s.zonePrefix+"n", styleButtonWithHover("^[n]ew", s.hoveredButton == "n"))
+	eButton := zone.Mark(s.zonePrefix+"e", styleButtonWithHover("^[e]dit", s.hoveredButton == "e"))
+	aButton := zone.Mark(s.zonePrefix+"a", styleButtonWithHover("^[a]child", s.hoveredButton == "a"))
+	xButton := zone.Mark(s.zonePrefix+"x", styleButtonWithHover("^[x]close", s.hoveredButton == "x"))
+	wButton := zone.Mark(s.zonePrefix+"w", styleButtonWithHover("^[w]ork", s.hoveredButton == "w"))
 	helpButton := zone.Mark(s.zonePrefix+"?", styleButtonWithHover("[?]help", s.hoveredButton == "?"))
 
 	commands := tButton + " " + cButton + " " + iButton + " " + rButton + " " + oButton + " " + vButton + " " + pButton + " " + fButton + " " + dButton + " " + sep + " " + nButton + " " + eButton + " " + aButton + " " + xButton + " " + wButton + " " + helpButton
-	commandsPlain := "⌥[t]erm ⌥[c]hat ⌥[i]DE ⌥[r]un ⌥[o]rch ⌥[v]review ⌥[p]r ⌥[f]eedback " + dLabelPlain + " | ⌥[n]ew ⌥[e]dit ⌥[a]child ⌥[x]close ⌥[w]ork [?]help"
+	commandsPlain := "^[t]erm ^[c]hat ^[i]DE ^[r]un ^[o]rch ^[v]review ^[p]r ^[f]eedback " + dLabelPlain + " | ^[n]ew ^[e]dit ^[a]child ^[x]close ^[w]ork [?]help"
 
 	return commands, commandsPlain
 }

--- a/internal/tui/tui_panel_work_details.go
+++ b/internal/tui/tui_panel_work_details.go
@@ -377,37 +377,37 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 
 		// Still handle action keys even when right panel is focused
 		switch msg.String() {
-		case "t":
+		case "ctrl+t":
 			return cmd, WorkDetailActionOpenTerminal
-		case "c":
+		case "ctrl+c":
 			return cmd, WorkDetailActionOpenAgent
-		case "i":
+		case "ctrl+i":
 			return cmd, WorkDetailActionOpenIDE
-		case "r":
+		case "ctrl+r":
 			return cmd, WorkDetailActionRun
-		case "v":
+		case "ctrl+v":
 			return cmd, WorkDetailActionReview
-		case "p":
-			// 'p' = plan when unassigned bean selected, PR otherwise
+		case "ctrl+p":
+			// ctrl+p = plan when unassigned bean selected, PR otherwise
 			if p.IsUnassignedBeanSelected() {
 				return cmd, WorkDetailActionPlan
 			}
 			return cmd, WorkDetailActionPR
-		case "o":
+		case "ctrl+o":
 			return cmd, WorkDetailActionRestartOrchestrator
-		case "f":
+		case "ctrl+f":
 			return cmd, WorkDetailActionCheckFeedback
-		case "d":
+		case "ctrl+d":
 			return cmd, WorkDetailActionDestroy
-		case "g":
+		case "ctrl+g":
 			return cmd, WorkDetailActionAttachTerminal
-		case "a":
+		case "ctrl+a":
 			// Add child issue - only when there's a focused work with root issue
 			if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
 				return cmd, WorkDetailActionAddChildIssue
 			}
 			return cmd, WorkDetailActionNone
-		case "x":
+		case "ctrl+x":
 			// Reset failed task - only when a failed task is selected
 			if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
 				return cmd, WorkDetailActionResetTask
@@ -428,36 +428,36 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 		// When left panel is focused, navigate selection
 		p.NavigateUp()
 		return nil, WorkDetailActionNavigateUp
-	case "t":
+	case "ctrl+t":
 		return nil, WorkDetailActionOpenTerminal
-	case "c":
+	case "ctrl+c":
 		return nil, WorkDetailActionOpenAgent
-	case "i":
+	case "ctrl+i":
 		return nil, WorkDetailActionOpenIDE
-	case "r":
+	case "ctrl+r":
 		return nil, WorkDetailActionRun
-	case "v":
+	case "ctrl+v":
 		return nil, WorkDetailActionReview
-	case "p":
-		// 'p' = plan when unassigned bean selected, PR otherwise
+	case "ctrl+p":
+		// ctrl+p = plan when unassigned bean selected, PR otherwise
 		if p.IsUnassignedBeanSelected() {
 			return nil, WorkDetailActionPlan
 		}
 		return nil, WorkDetailActionPR
-	case "o":
+	case "ctrl+o":
 		return nil, WorkDetailActionRestartOrchestrator
-	case "f":
+	case "ctrl+f":
 		return nil, WorkDetailActionCheckFeedback
-	case "d":
+	case "ctrl+d":
 		return nil, WorkDetailActionDestroy
-	case "g":
+	case "ctrl+g":
 		return nil, WorkDetailActionAttachTerminal
-	case "a":
+	case "ctrl+a":
 		// Add child issue - only when there's a focused work with root issue
 		if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
 			return nil, WorkDetailActionAddChildIssue
 		}
-	case "x":
+	case "ctrl+x":
 		// Reset failed task - only when a failed task is selected
 		if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
 			return nil, WorkDetailActionResetTask

--- a/internal/tui/tui_panel_work_details.go
+++ b/internal/tui/tui_panel_work_details.go
@@ -375,47 +375,11 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 			*vp, cmd = vp.Update(msg)
 		}
 
-		// Still handle action keys even when right panel is focused
-		switch msg.String() {
-		case "alt+t":
-			return cmd, WorkDetailActionOpenTerminal
-		case "alt+c":
-			return cmd, WorkDetailActionOpenAgent
-		case "alt+i":
-			return cmd, WorkDetailActionOpenIDE
-		case "alt+r":
-			return cmd, WorkDetailActionRun
-		case "alt+v":
-			return cmd, WorkDetailActionReview
-		case "alt+p":
-			// alt+p = plan when unassigned bean selected, PR otherwise
-			if p.IsUnassignedBeanSelected() {
-				return cmd, WorkDetailActionPlan
-			}
-			return cmd, WorkDetailActionPR
-		case "alt+o":
-			return cmd, WorkDetailActionRestartOrchestrator
-		case "alt+f":
-			return cmd, WorkDetailActionCheckFeedback
-		case "alt+d":
-			return cmd, WorkDetailActionDestroy
-		case "alt+g":
-			return cmd, WorkDetailActionAttachTerminal
-		case "alt+a":
-			// Add child issue - only when there's a focused work with root issue
-			if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
-				return cmd, WorkDetailActionAddChildIssue
-			}
-			return cmd, WorkDetailActionNone
-		case "alt+x":
-			// Reset failed task - only when a failed task is selected
-			if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
-				return cmd, WorkDetailActionResetTask
-			}
-			return cmd, WorkDetailActionNone
-		default:
-			return cmd, WorkDetailActionNone
+		// Still handle alt+key action keys even when right panel is focused
+		if action := p.handleAltAction(msg); action != WorkDetailActionNone {
+			return cmd, action
 		}
+		return cmd, WorkDetailActionNone
 	}
 
 	// When left panel is focused, handle navigation and actions
@@ -428,43 +392,58 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 		// When left panel is focused, navigate selection
 		p.NavigateUp()
 		return nil, WorkDetailActionNavigateUp
-	case "alt+t":
-		return nil, WorkDetailActionOpenTerminal
-	case "alt+c":
-		return nil, WorkDetailActionOpenAgent
-	case "alt+i":
-		return nil, WorkDetailActionOpenIDE
-	case "alt+r":
-		return nil, WorkDetailActionRun
-	case "alt+v":
-		return nil, WorkDetailActionReview
-	case "alt+p":
-		// alt+p = plan when unassigned bean selected, PR otherwise
-		if p.IsUnassignedBeanSelected() {
-			return nil, WorkDetailActionPlan
-		}
-		return nil, WorkDetailActionPR
-	case "alt+o":
-		return nil, WorkDetailActionRestartOrchestrator
-	case "alt+f":
-		return nil, WorkDetailActionCheckFeedback
-	case "alt+d":
-		return nil, WorkDetailActionDestroy
-	case "alt+g":
-		return nil, WorkDetailActionAttachTerminal
-	case "alt+a":
-		// Add child issue - only when there's a focused work with root issue
-		if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
-			return nil, WorkDetailActionAddChildIssue
-		}
-	case "alt+x":
-		// Reset failed task - only when a failed task is selected
-		if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
-			return nil, WorkDetailActionResetTask
-		}
+	}
+
+	// Handle alt+key actions from left panel
+	if action := p.handleAltAction(msg); action != WorkDetailActionNone {
+		return nil, action
 	}
 
 	return nil, WorkDetailActionNone
+}
+
+// handleAltAction maps alt+key combos to work detail actions.
+// Uses msg.Mod and msg.Code directly since msg.String() doesn't reliably
+// include the alt modifier (it returns the Text field instead).
+func (p *WorkDetailsPanel) handleAltAction(msg tea.KeyPressMsg) WorkDetailAction {
+	k := altKey(msg)
+	switch k {
+	case 't':
+		return WorkDetailActionOpenTerminal
+	case 'c':
+		return WorkDetailActionOpenAgent
+	case 'i':
+		return WorkDetailActionOpenIDE
+	case 'r':
+		return WorkDetailActionRun
+	case 'v':
+		return WorkDetailActionReview
+	case 'p':
+		// alt+p = plan when unassigned bean selected, PR otherwise
+		if p.IsUnassignedBeanSelected() {
+			return WorkDetailActionPlan
+		}
+		return WorkDetailActionPR
+	case 'o':
+		return WorkDetailActionRestartOrchestrator
+	case 'f':
+		return WorkDetailActionCheckFeedback
+	case 'd':
+		return WorkDetailActionDestroy
+	case 'g':
+		return WorkDetailActionAttachTerminal
+	case 'a':
+		// Add child issue - only when there's a focused work with root issue
+		if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
+			return WorkDetailActionAddChildIssue
+		}
+	case 'x':
+		// Reset failed task - only when a failed task is selected
+		if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
+			return WorkDetailActionResetTask
+		}
+	}
+	return WorkDetailActionNone
 }
 
 // DetectClickedItem determines which item was clicked and returns its index

--- a/internal/tui/tui_panel_work_details.go
+++ b/internal/tui/tui_panel_work_details.go
@@ -375,8 +375,8 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 			*vp, cmd = vp.Update(msg)
 		}
 
-		// Still handle alt+key action keys even when right panel is focused
-		if action := p.handleAltAction(msg); action != WorkDetailActionNone {
+		// Still handle ctrl+key action keys even when right panel is focused
+		if action := p.handleCtrlAction(msg); action != WorkDetailActionNone {
 			return cmd, action
 		}
 		return cmd, WorkDetailActionNone
@@ -394,19 +394,18 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 		return nil, WorkDetailActionNavigateUp
 	}
 
-	// Handle alt+key actions from left panel
-	if action := p.handleAltAction(msg); action != WorkDetailActionNone {
+	// Handle ctrl+key actions from left panel
+	if action := p.handleCtrlAction(msg); action != WorkDetailActionNone {
 		return nil, action
 	}
 
 	return nil, WorkDetailActionNone
 }
 
-// handleAltAction maps alt+key combos to work detail actions.
-// Uses msg.Mod and msg.Code directly since msg.String() doesn't reliably
-// include the alt modifier (it returns the Text field instead).
-func (p *WorkDetailsPanel) handleAltAction(msg tea.KeyPressMsg) WorkDetailAction {
-	k := altKey(msg)
+// handleCtrlAction maps ctrl+key combos to work detail actions.
+// Uses msg.Mod and msg.Code directly for reliable modifier detection.
+func (p *WorkDetailsPanel) handleCtrlAction(msg tea.KeyPressMsg) WorkDetailAction {
+	k := ctrlKey(msg)
 	switch k {
 	case 't':
 		return WorkDetailActionOpenTerminal
@@ -419,7 +418,7 @@ func (p *WorkDetailsPanel) handleAltAction(msg tea.KeyPressMsg) WorkDetailAction
 	case 'v':
 		return WorkDetailActionReview
 	case 'p':
-		// alt+p = plan when unassigned bean selected, PR otherwise
+		// ctrl+p = plan when unassigned bean selected, PR otherwise
 		if p.IsUnassignedBeanSelected() {
 			return WorkDetailActionPlan
 		}

--- a/internal/tui/tui_panel_work_details.go
+++ b/internal/tui/tui_panel_work_details.go
@@ -377,37 +377,37 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 
 		// Still handle action keys even when right panel is focused
 		switch msg.String() {
-		case "ctrl+t":
+		case "alt+t":
 			return cmd, WorkDetailActionOpenTerminal
-		case "ctrl+c":
+		case "alt+c":
 			return cmd, WorkDetailActionOpenAgent
-		case "ctrl+i":
+		case "alt+i":
 			return cmd, WorkDetailActionOpenIDE
-		case "ctrl+r":
+		case "alt+r":
 			return cmd, WorkDetailActionRun
-		case "ctrl+v":
+		case "alt+v":
 			return cmd, WorkDetailActionReview
-		case "ctrl+p":
-			// ctrl+p = plan when unassigned bean selected, PR otherwise
+		case "alt+p":
+			// alt+p = plan when unassigned bean selected, PR otherwise
 			if p.IsUnassignedBeanSelected() {
 				return cmd, WorkDetailActionPlan
 			}
 			return cmd, WorkDetailActionPR
-		case "ctrl+o":
+		case "alt+o":
 			return cmd, WorkDetailActionRestartOrchestrator
-		case "ctrl+f":
+		case "alt+f":
 			return cmd, WorkDetailActionCheckFeedback
-		case "ctrl+d":
+		case "alt+d":
 			return cmd, WorkDetailActionDestroy
-		case "ctrl+g":
+		case "alt+g":
 			return cmd, WorkDetailActionAttachTerminal
-		case "ctrl+a":
+		case "alt+a":
 			// Add child issue - only when there's a focused work with root issue
 			if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
 				return cmd, WorkDetailActionAddChildIssue
 			}
 			return cmd, WorkDetailActionNone
-		case "ctrl+x":
+		case "alt+x":
 			// Reset failed task - only when a failed task is selected
 			if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
 				return cmd, WorkDetailActionResetTask
@@ -428,36 +428,36 @@ func (p *WorkDetailsPanel) Update(msg tea.KeyPressMsg) (tea.Cmd, WorkDetailActio
 		// When left panel is focused, navigate selection
 		p.NavigateUp()
 		return nil, WorkDetailActionNavigateUp
-	case "ctrl+t":
+	case "alt+t":
 		return nil, WorkDetailActionOpenTerminal
-	case "ctrl+c":
+	case "alt+c":
 		return nil, WorkDetailActionOpenAgent
-	case "ctrl+i":
+	case "alt+i":
 		return nil, WorkDetailActionOpenIDE
-	case "ctrl+r":
+	case "alt+r":
 		return nil, WorkDetailActionRun
-	case "ctrl+v":
+	case "alt+v":
 		return nil, WorkDetailActionReview
-	case "ctrl+p":
-		// ctrl+p = plan when unassigned bean selected, PR otherwise
+	case "alt+p":
+		// alt+p = plan when unassigned bean selected, PR otherwise
 		if p.IsUnassignedBeanSelected() {
 			return nil, WorkDetailActionPlan
 		}
 		return nil, WorkDetailActionPR
-	case "ctrl+o":
+	case "alt+o":
 		return nil, WorkDetailActionRestartOrchestrator
-	case "ctrl+f":
+	case "alt+f":
 		return nil, WorkDetailActionCheckFeedback
-	case "ctrl+d":
+	case "alt+d":
 		return nil, WorkDetailActionDestroy
-	case "ctrl+g":
+	case "alt+g":
 		return nil, WorkDetailActionAttachTerminal
-	case "ctrl+a":
+	case "alt+a":
 		// Add child issue - only when there's a focused work with root issue
 		if p.focusedWork != nil && p.focusedWork.Work.RootIssueID != "" {
 			return nil, WorkDetailActionAddChildIssue
 		}
-	case "ctrl+x":
+	case "alt+x":
 		// Reset failed task - only when a failed task is selected
 		if p.IsTaskSelected() && p.IsSelectedTaskFailed() {
 			return nil, WorkDetailActionResetTask

--- a/internal/tui/tui_panel_work_task.go
+++ b/internal/tui/tui_panel_work_task.go
@@ -202,7 +202,7 @@ func (p *WorkTaskPanel) renderUnassignedBeanDetails(panelWidth int) string {
 	warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	content.WriteString(warningStyle.Render("Unassigned Issue"))
 	content.WriteString(" ")
-	content.WriteString(tuiDimStyle.Render("[p] plan [r] run"))
+	content.WriteString(tuiDimStyle.Render("[ctrl+p] plan [ctrl+r] run"))
 	content.WriteString("\n\n")
 
 	fmt.Fprintf(&content, "ID: %s\n", bean.ID)

--- a/internal/tui/tui_panel_work_task.go
+++ b/internal/tui/tui_panel_work_task.go
@@ -202,7 +202,7 @@ func (p *WorkTaskPanel) renderUnassignedBeanDetails(panelWidth int) string {
 	warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	content.WriteString(warningStyle.Render("Unassigned Issue"))
 	content.WriteString(" ")
-	content.WriteString(tuiDimStyle.Render("[alt+p] plan [alt+r] run"))
+	content.WriteString(tuiDimStyle.Render("[^p] plan [^r] run"))
 	content.WriteString("\n\n")
 
 	fmt.Fprintf(&content, "ID: %s\n", bean.ID)

--- a/internal/tui/tui_panel_work_task.go
+++ b/internal/tui/tui_panel_work_task.go
@@ -202,7 +202,7 @@ func (p *WorkTaskPanel) renderUnassignedBeanDetails(panelWidth int) string {
 	warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	content.WriteString(warningStyle.Render("Unassigned Issue"))
 	content.WriteString(" ")
-	content.WriteString(tuiDimStyle.Render("[ctrl+p] plan [ctrl+r] run"))
+	content.WriteString(tuiDimStyle.Render("[alt+p] plan [alt+r] run"))
 	content.WriteString("\n\n")
 
 	fmt.Fprintf(&content, "ID: %s\n", bean.ID)

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -510,33 +510,33 @@ func (m *planModel) Update(msg tea.Msg) (*planModel, tea.Cmd) {
 				// Trigger the corresponding action by simulating a key press
 				switch clickedButton {
 				case "n":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
 				case "e":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 				case "a":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl})
 				case "x":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 				case "d":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 				case "w":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl})
 				case "p":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
 				case "t":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
 				case "c":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
 				case "i":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'i', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'i', Mod: tea.ModCtrl})
 				case "r":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'r', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 				case "o":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 				case "v":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'v', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
 				case "f":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'f', Mod: tea.ModAlt})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
 				case "?":
 					return m.handleKeyPress(tea.KeyPressMsg{Code: '?', Text: "?"})
 				}
@@ -1101,24 +1101,8 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 				return m, nil
 			}
 
-			// Intercept alt+key TUI hotkeys before forwarding to PTY.
-			// This allows TUI control without leaving the session.
-			// We use alt+ (not ctrl+) because pi sessions use ctrl+c, ctrl+d,
-			// ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k.
-			if k := altKey(msg); k != 0 {
-				goto handleNormalKeys
-			}
-			if k := altShiftKey(msg); k != 0 {
-				goto handleNormalKeys
-			}
-			// Also intercept ctrl+shift+1-9 for sub-session switching (no pi conflict)
-			if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 {
-				if msg.Code >= '1' && msg.Code <= '9' {
-					goto handleNormalKeys
-				}
-			}
-
-			// Forward all other keys to the PTY session
+			// Forward all keys to the PTY session.
+			// Pi sessions get complete keyboard control — only ESC exits.
 			session := activeTab.ActiveSession(m.ptyManager)
 			if session != nil && session.State() != ptysession.SessionDead {
 				raw := keyMsgToBytes(msg)
@@ -1135,8 +1119,6 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 			}
 		}
 	}
-
-handleNormalKeys:
 
 	// Handle escape key globally for deselecting focused work
 	if msg.Code == tea.KeyEscape && m.viewMode == ViewNormal && m.focusedWorkID != "" {
@@ -1371,12 +1353,12 @@ handleNormalKeys:
 	// and [d]elete bean when issues panel is focused.
 	if m.focusedWorkID != "" {
 		isWorkActionKey := false
-		if k := altKey(msg); k != 0 {
+		if k := ctrlKey(msg); k != 0 {
 			switch k {
 			case 't', 'c', 'i', 'r', 'o', 'f', 'g', 'v', 'p', 'x', 'a':
 				isWorkActionKey = true
 			case 'd':
-				// alt+d is panel-aware: destroy work when work panel is focused,
+				// ctrl+d is panel-aware: destroy work when work panel is focused,
 				// delete bean when issues panel is focused
 				if m.activePanel == PanelWorkDetails || m.activePanel == PanelWorkTabs {
 					isWorkActionKey = true
@@ -1500,30 +1482,18 @@ handleNormalKeys:
 		return m.selectWorkByIndex(digit)
 	}
 
-	// Handle alt+key action hotkeys.
-	// We use alt+ (not ctrl+) to avoid conflicting with pi session hotkeys
-	// (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k).
-	// We check msg.Mod and msg.Code directly because msg.String() returns the
-	// Text field which doesn't include modifier info for alt+key on most terminals.
-	if k := altKey(msg); k != 0 {
-		return m.handleAltKey(k)
+	// Handle ctrl+key action hotkeys.
+	// When a pi session is focused, only ESC exits — all keys go to the PTY.
+	// When any other panel is focused, ctrl+key triggers TUI actions.
+	if k := ctrlKey(msg); k != 0 {
+		return m.handleCtrlKey(k)
 	}
-	if k := altShiftKey(msg); k != 0 {
-		return m.handleAltShiftKey(k)
+	if k := ctrlShiftKey(msg); k != 0 {
+		return m.handleCtrlShiftKey(k, msg)
 	}
-	// ctrl+shift+1-9 for sub-session switching (no pi conflict)
-	if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 {
-		if msg.Code >= '1' && msg.Code <= '9' {
-			if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-				idx := int(msg.Code - '0')
-				activeTab.SetSubSessionByIndex(m.ptyManager, idx)
-				sessionID := activeTab.ResolveSessionID(m.ptyManager)
-				if sessionID != "" {
-					m.viewPTYSession(sessionID)
-				}
-			}
-			return m, nil
-		}
+	// ctrl+shift+digit for sub-session switching
+	if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 && msg.Code >= '1' && msg.Code <= '9' {
+		return m.handleCtrlShiftKey(0, msg)
 	}
 
 	switch msg.String() {
@@ -1696,10 +1666,9 @@ handleNormalKeys:
 	return m, nil
 }
 
-// handleAltKey handles alt+letter hotkeys for TUI actions.
-// Uses the letter code directly (e.g., 'n' for alt+n) since msg.String()
-// doesn't reliably include the alt modifier.
-func (m *planModel) handleAltKey(k rune) (*planModel, tea.Cmd) {
+// handleCtrlKey handles ctrl+letter hotkeys for TUI actions.
+// Uses msg.Mod and msg.Code directly for reliable modifier detection.
+func (m *planModel) handleCtrlKey(k rune) (*planModel, tea.Cmd) {
 	switch k {
 	case 'n':
 		// Create new bean inline
@@ -1844,8 +1813,22 @@ func (m *planModel) handleAltKey(k rune) (*planModel, tea.Cmd) {
 	return m, nil
 }
 
-// handleAltShiftKey handles alt+shift+letter hotkeys for TUI actions.
-func (m *planModel) handleAltShiftKey(k rune) (*planModel, tea.Cmd) {
+// handleCtrlShiftKey handles ctrl+shift+letter hotkeys for TUI actions.
+func (m *planModel) handleCtrlShiftKey(k rune, msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
+	// Handle ctrl+shift+1-9 for sub-session switching
+	// (ctrlShiftKey only returns letters, so check digits via msg.Code)
+	if k == 0 && msg.Code >= '1' && msg.Code <= '9' {
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			idx := int(msg.Code - '0')
+			activeTab.SetSubSessionByIndex(m.ptyManager, idx)
+			sessionID := activeTab.ResolveSessionID(m.ptyManager)
+			if sessionID != "" {
+				m.viewPTYSession(sessionID)
+			}
+		}
+		return m, nil
+	}
+
 	switch k {
 	case 'e':
 		// Edit selected issue in external editor

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -510,33 +510,33 @@ func (m *planModel) Update(msg tea.Msg) (*planModel, tea.Cmd) {
 				// Trigger the corresponding action by simulating a key press
 				switch clickedButton {
 				case "n":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModAlt})
 				case "e":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Mod: tea.ModAlt})
 				case "a":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Mod: tea.ModAlt})
 				case "x":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModAlt})
 				case "d":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Mod: tea.ModAlt})
 				case "w":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModAlt})
 				case "p":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Mod: tea.ModAlt})
 				case "t":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModAlt})
 				case "c":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModAlt})
 				case "i":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'i', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'i', Mod: tea.ModAlt})
 				case "r":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'r', Mod: tea.ModAlt})
 				case "o":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModAlt})
 				case "v":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'v', Mod: tea.ModAlt})
 				case "f":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'f', Mod: tea.ModAlt})
 				case "?":
 					return m.handleKeyPress(tea.KeyPressMsg{Code: '?', Text: "?"})
 				}
@@ -1101,18 +1101,26 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 				return m, nil
 			}
 
-			// Intercept ctrl+key TUI hotkeys before forwarding to PTY.
+			// Intercept alt+key TUI hotkeys before forwarding to PTY.
 			// This allows TUI control without leaving the session.
-			if msg.Mod&tea.ModCtrl != 0 {
+			// We use alt+ (not ctrl+) because pi sessions use ctrl+c, ctrl+d,
+			// ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k.
+			if msg.Mod&tea.ModAlt != 0 {
 				switch msg.String() {
-				case "ctrl+n", "ctrl+e", "ctrl+a", "ctrl+x", "ctrl+d", "ctrl+w", "ctrl+p",
-					"ctrl+t", "ctrl+r", "ctrl+o", "ctrl+f", "ctrl+g", "ctrl+v",
-					"ctrl+s", "ctrl+q", "ctrl+z",
-					"ctrl+m", "ctrl+i", "ctrl+c",
-					"ctrl+shift+e", "ctrl+shift+m", "ctrl+shift+a",
-					"ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4",
-					"ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
+				case "alt+n", "alt+e", "alt+a", "alt+x", "alt+d", "alt+w", "alt+p",
+					"alt+t", "alt+r", "alt+o", "alt+f", "alt+g", "alt+v",
+					"alt+s", "alt+q", "alt+z",
+					"alt+m", "alt+i", "alt+c",
+					"alt+shift+e", "alt+shift+m", "alt+shift+a":
 					// Fall through to normal key handling below
+					goto handleNormalKeys
+				}
+			}
+			// Also intercept ctrl+shift+1-9 for sub-session switching (no pi conflict)
+			if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 {
+				switch msg.String() {
+				case "ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4",
+					"ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
 					goto handleNormalKeys
 				}
 			}
@@ -1371,10 +1379,10 @@ handleNormalKeys:
 	if m.focusedWorkID != "" {
 		isWorkActionKey := false
 		switch msg.String() {
-		case "ctrl+t", "ctrl+c", "ctrl+i", "ctrl+r", "ctrl+o", "ctrl+f", "ctrl+g", "ctrl+v", "ctrl+p", "ctrl+x", "ctrl+a":
+		case "alt+t", "alt+c", "alt+i", "alt+r", "alt+o", "alt+f", "alt+g", "alt+v", "alt+p", "alt+x", "alt+a":
 			isWorkActionKey = true
-		case "ctrl+d":
-			// ctrl+d is panel-aware: destroy work when work panel is focused,
+		case "alt+d":
+			// alt+d is panel-aware: destroy work when work panel is focused,
 			// delete bean when issues panel is focused
 			if m.activePanel == PanelWorkDetails || m.activePanel == PanelWorkTabs {
 				isWorkActionKey = true
@@ -1585,13 +1593,13 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+n":
+	case "alt+n":
 		// Create new bean inline
 		m.viewMode = ViewCreateBeanInline
 		m.beanFormPanel.Reset()
 		return m, m.beanFormPanel.Init()
 
-	case "ctrl+x":
+	case "alt+x":
 		// Close selected bean(s)
 		if len(m.beanItems) > 0 {
 			// Check if we have any selected beans
@@ -1609,7 +1617,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+d":
+	case "alt+d":
 		// Delete selected bean(s) permanently
 		if len(m.beanItems) > 0 {
 			// Check if we have any selected beans
@@ -1663,7 +1671,7 @@ handleNormalKeys:
 		m.filters.status = "ready"
 		return m, m.refreshData()
 
-	case "ctrl+s":
+	case "alt+s":
 		// Cycle sort mode
 		switch m.filters.sortBy {
 		case "default":
@@ -1687,7 +1695,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+z":
+	case "alt+z":
 		// Toggle session maximize for the active work tab
 		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
 			activeTab.SessionMaximized = !activeTab.SessionMaximized
@@ -1742,15 +1750,15 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+p":
-		// Spawn/resume planning session for selected bean (work details panel handles ctrl+p for Plan)
+	case "alt+p":
+		// Spawn/resume planning session for selected bean (work details panel handles alt+p for Plan)
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			beanID := m.beanItems[m.beansCursor].ID
 			return m, m.spawnPlanSession(beanID)
 		}
 		return m, nil
 
-	case "ctrl+w":
+	case "alt+w":
 		// Create work from cursor bean - show dialog
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1772,7 +1780,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+a":
+	case "alt+a":
 		// Add child issue to selected issue
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			parent := m.beanItems[m.beansCursor]
@@ -1787,7 +1795,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+e":
+	case "alt+e":
 		// Edit selected issue using the unified bean form
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1797,7 +1805,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+shift+e":
+	case "alt+shift+e":
 		// Edit selected issue in external editor
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1805,7 +1813,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "ctrl+m":
+	case "alt+m":
 		// Import Linear issue inline - check for API key first
 		var apiKey string
 		if m.proj.Config != nil {
@@ -1820,13 +1828,13 @@ handleNormalKeys:
 		m.linearImportPanel.Reset()
 		return m, m.linearImportPanel.Init()
 
-	case "ctrl+shift+m":
+	case "alt+shift+m":
 		// Import GitHub PR inline
 		m.viewMode = ViewPRImportInline
 		m.prImportPanel.Reset()
 		return m, m.prImportPanel.Init()
 
-	case "ctrl+shift+a":
+	case "alt+shift+a":
 		// Add selected issue(s) to the focused work
 		if m.focusedWorkID == "" {
 			m.statusMessage = "Select a work first (press 1-9 to select a work)"
@@ -1873,7 +1881,7 @@ handleNormalKeys:
 		m.viewMode = ViewHelp
 		return m, nil
 
-	case "ctrl+q":
+	case "alt+q":
 		// Clean up resources before quitting
 		m.cleanup()
 		return m, tea.Quit

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -510,19 +510,33 @@ func (m *planModel) Update(msg tea.Msg) (*planModel, tea.Cmd) {
 				// Trigger the corresponding action by simulating a key press
 				switch clickedButton {
 				case "n":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Text: "n"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
 				case "e":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Text: "e"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 				case "a":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Text: "a"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl})
 				case "x":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Text: "x"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 				case "d":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Text: "d"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 				case "w":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Text: "w"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl})
 				case "p":
-					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Text: "p"})
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
+				case "t":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+				case "c":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+				case "i":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'i', Mod: tea.ModCtrl})
+				case "r":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+				case "o":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+				case "v":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+				case "f":
+					return m.handleKeyPress(tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
 				case "?":
 					return m.handleKeyPress(tea.KeyPressMsg{Code: '?', Text: "?"})
 				}
@@ -1087,6 +1101,22 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 				return m, nil
 			}
 
+			// Intercept ctrl+key TUI hotkeys before forwarding to PTY.
+			// This allows TUI control without leaving the session.
+			if msg.Mod&tea.ModCtrl != 0 {
+				switch msg.String() {
+				case "ctrl+n", "ctrl+e", "ctrl+a", "ctrl+x", "ctrl+d", "ctrl+w", "ctrl+p",
+					"ctrl+t", "ctrl+r", "ctrl+o", "ctrl+f", "ctrl+g", "ctrl+v",
+					"ctrl+s", "ctrl+q", "ctrl+z",
+					"ctrl+m", "ctrl+i", "ctrl+c",
+					"ctrl+shift+e", "ctrl+shift+m", "ctrl+shift+a",
+					"ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4",
+					"ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
+					// Fall through to normal key handling below
+					goto handleNormalKeys
+				}
+			}
+
 			// Forward all other keys to the PTY session
 			session := activeTab.ActiveSession(m.ptyManager)
 			if session != nil && session.State() != ptysession.SessionDead {
@@ -1104,6 +1134,8 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 			}
 		}
 	}
+
+handleNormalKeys:
 
 	// Handle escape key globally for deselecting focused work
 	if msg.Code == tea.KeyEscape && m.viewMode == ViewNormal && m.focusedWorkID != "" {
@@ -1339,10 +1371,10 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 	if m.focusedWorkID != "" {
 		isWorkActionKey := false
 		switch msg.String() {
-		case "t", "c", "i", "r", "o", "f", "g", "v", "p", "x", "a":
+		case "ctrl+t", "ctrl+c", "ctrl+i", "ctrl+r", "ctrl+o", "ctrl+f", "ctrl+g", "ctrl+v", "ctrl+p", "ctrl+x", "ctrl+a":
 			isWorkActionKey = true
-		case "d":
-			// 'd' is panel-aware: destroy work when work panel is focused,
+		case "ctrl+d":
+			// ctrl+d is panel-aware: destroy work when work panel is focused,
 			// delete bean when issues panel is focused
 			if m.activePanel == PanelWorkDetails || m.activePanel == PanelWorkTabs {
 				isWorkActionKey = true
@@ -1553,13 +1585,13 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "n":
+	case "ctrl+n":
 		// Create new bean inline
 		m.viewMode = ViewCreateBeanInline
 		m.beanFormPanel.Reset()
 		return m, m.beanFormPanel.Init()
 
-	case "x":
+	case "ctrl+x":
 		// Close selected bean(s)
 		if len(m.beanItems) > 0 {
 			// Check if we have any selected beans
@@ -1577,7 +1609,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "d":
+	case "ctrl+d":
 		// Delete selected bean(s) permanently
 		if len(m.beanItems) > 0 {
 			// Check if we have any selected beans
@@ -1631,7 +1663,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		m.filters.status = "ready"
 		return m, m.refreshData()
 
-	case "s":
+	case "ctrl+s":
 		// Cycle sort mode
 		switch m.filters.sortBy {
 		case "default":
@@ -1643,7 +1675,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, m.refreshData()
 
-	case "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4", "ctrl+5", "ctrl+6", "ctrl+7", "ctrl+8", "ctrl+9":
+	case "ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4", "ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
 		// Switch to sub-session by index
 		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
 			idx := int(msg.String()[len(msg.String())-1] - '0')
@@ -1655,7 +1687,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "z":
+	case "ctrl+z":
 		// Toggle session maximize for the active work tab
 		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
 			activeTab.SessionMaximized = !activeTab.SessionMaximized
@@ -1710,15 +1742,15 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "p":
-		// Spawn/resume planning session for selected bean (work details panel handles 'p' for Plan)
+	case "ctrl+p":
+		// Spawn/resume planning session for selected bean (work details panel handles ctrl+p for Plan)
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			beanID := m.beanItems[m.beansCursor].ID
 			return m, m.spawnPlanSession(beanID)
 		}
 		return m, nil
 
-	case "w":
+	case "ctrl+w":
 		// Create work from cursor bean - show dialog
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1740,7 +1772,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "a":
+	case "ctrl+a":
 		// Add child issue to selected issue
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			parent := m.beanItems[m.beansCursor]
@@ -1755,7 +1787,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "e":
+	case "ctrl+e":
 		// Edit selected issue using the unified bean form
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1765,7 +1797,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "E":
+	case "ctrl+shift+e":
 		// Edit selected issue in external editor
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1773,7 +1805,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case "m":
+	case "ctrl+m":
 		// Import Linear issue inline - check for API key first
 		var apiKey string
 		if m.proj.Config != nil {
@@ -1788,13 +1820,13 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		m.linearImportPanel.Reset()
 		return m, m.linearImportPanel.Init()
 
-	case "M":
+	case "ctrl+shift+m":
 		// Import GitHub PR inline
 		m.viewMode = ViewPRImportInline
 		m.prImportPanel.Reset()
 		return m, m.prImportPanel.Init()
 
-	case "A":
+	case "ctrl+shift+a":
 		// Add selected issue(s) to the focused work
 		if m.focusedWorkID == "" {
 			m.statusMessage = "Select a work first (press 1-9 to select a work)"
@@ -1841,7 +1873,7 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 		m.viewMode = ViewHelp
 		return m, nil
 
-	case "q":
+	case "ctrl+q":
 		// Clean up resources before quitting
 		m.cleanup()
 		return m, tea.Quit

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -1105,22 +1105,15 @@ func (m *planModel) handleKeyPress(msg tea.KeyPressMsg) (*planModel, tea.Cmd) {
 			// This allows TUI control without leaving the session.
 			// We use alt+ (not ctrl+) because pi sessions use ctrl+c, ctrl+d,
 			// ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k.
-			if msg.Mod&tea.ModAlt != 0 {
-				switch msg.String() {
-				case "alt+n", "alt+e", "alt+a", "alt+x", "alt+d", "alt+w", "alt+p",
-					"alt+t", "alt+r", "alt+o", "alt+f", "alt+g", "alt+v",
-					"alt+s", "alt+q", "alt+z",
-					"alt+m", "alt+i", "alt+c",
-					"alt+shift+e", "alt+shift+m", "alt+shift+a":
-					// Fall through to normal key handling below
-					goto handleNormalKeys
-				}
+			if k := altKey(msg); k != 0 {
+				goto handleNormalKeys
+			}
+			if k := altShiftKey(msg); k != 0 {
+				goto handleNormalKeys
 			}
 			// Also intercept ctrl+shift+1-9 for sub-session switching (no pi conflict)
 			if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 {
-				switch msg.String() {
-				case "ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4",
-					"ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
+				if msg.Code >= '1' && msg.Code <= '9' {
 					goto handleNormalKeys
 				}
 			}
@@ -1378,14 +1371,16 @@ handleNormalKeys:
 	// and [d]elete bean when issues panel is focused.
 	if m.focusedWorkID != "" {
 		isWorkActionKey := false
-		switch msg.String() {
-		case "alt+t", "alt+c", "alt+i", "alt+r", "alt+o", "alt+f", "alt+g", "alt+v", "alt+p", "alt+x", "alt+a":
-			isWorkActionKey = true
-		case "alt+d":
-			// alt+d is panel-aware: destroy work when work panel is focused,
-			// delete bean when issues panel is focused
-			if m.activePanel == PanelWorkDetails || m.activePanel == PanelWorkTabs {
+		if k := altKey(msg); k != 0 {
+			switch k {
+			case 't', 'c', 'i', 'r', 'o', 'f', 'g', 'v', 'p', 'x', 'a':
 				isWorkActionKey = true
+			case 'd':
+				// alt+d is panel-aware: destroy work when work panel is focused,
+				// delete bean when issues panel is focused
+				if m.activePanel == PanelWorkDetails || m.activePanel == PanelWorkTabs {
+					isWorkActionKey = true
+				}
 			}
 		}
 
@@ -1505,6 +1500,32 @@ handleNormalKeys:
 		return m.selectWorkByIndex(digit)
 	}
 
+	// Handle alt+key action hotkeys.
+	// We use alt+ (not ctrl+) to avoid conflicting with pi session hotkeys
+	// (ctrl+c, ctrl+d, ctrl+z, ctrl+p, ctrl+t, ctrl+o, ctrl+g, ctrl+v, ctrl+l, ctrl+k).
+	// We check msg.Mod and msg.Code directly because msg.String() returns the
+	// Text field which doesn't include modifier info for alt+key on most terminals.
+	if k := altKey(msg); k != 0 {
+		return m.handleAltKey(k)
+	}
+	if k := altShiftKey(msg); k != 0 {
+		return m.handleAltShiftKey(k)
+	}
+	// ctrl+shift+1-9 for sub-session switching (no pi conflict)
+	if msg.Mod&tea.ModCtrl != 0 && msg.Mod&tea.ModShift != 0 {
+		if msg.Code >= '1' && msg.Code <= '9' {
+			if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+				idx := int(msg.Code - '0')
+				activeTab.SetSubSessionByIndex(m.ptyManager, idx)
+				sessionID := activeTab.ResolveSessionID(m.ptyManager)
+				if sessionID != "" {
+					m.viewPTYSession(sessionID)
+				}
+			}
+			return m, nil
+		}
+	}
+
 	switch msg.String() {
 	case "tab":
 		// In focused work mode: cycle between work details, session, and issues
@@ -1593,48 +1614,6 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "alt+n":
-		// Create new bean inline
-		m.viewMode = ViewCreateBeanInline
-		m.beanFormPanel.Reset()
-		return m, m.beanFormPanel.Init()
-
-	case "alt+x":
-		// Close selected bean(s)
-		if len(m.beanItems) > 0 {
-			// Check if we have any selected beans
-			hasSelection := false
-			for _, item := range m.beanItems {
-				if m.selectedBeans[item.ID] {
-					hasSelection = true
-					break
-				}
-			}
-			// If we have selected beans or a cursor bean, show confirmation
-			if hasSelection || m.beansCursor < len(m.beanItems) {
-				m.viewMode = ViewCloseBeanConfirm
-			}
-		}
-		return m, nil
-
-	case "alt+d":
-		// Delete selected bean(s) permanently
-		if len(m.beanItems) > 0 {
-			// Check if we have any selected beans
-			hasSelection := false
-			for _, item := range m.beanItems {
-				if m.selectedBeans[item.ID] {
-					hasSelection = true
-					break
-				}
-			}
-			// If we have selected beans or a cursor bean, show confirmation
-			if hasSelection || m.beansCursor < len(m.beanItems) {
-				m.viewMode = ViewDeleteBeanConfirm
-			}
-		}
-		return m, nil
-
 	case "/":
 		// Search
 		m.viewMode = ViewBeanSearch
@@ -1670,47 +1649,6 @@ handleNormalKeys:
 	case "R":
 		m.filters.status = "ready"
 		return m, m.refreshData()
-
-	case "alt+s":
-		// Cycle sort mode
-		switch m.filters.sortBy {
-		case "default":
-			m.filters.sortBy = "priority"
-		case "priority":
-			m.filters.sortBy = "title"
-		default:
-			m.filters.sortBy = "default"
-		}
-		return m, m.refreshData()
-
-	case "ctrl+shift+1", "ctrl+shift+2", "ctrl+shift+3", "ctrl+shift+4", "ctrl+shift+5", "ctrl+shift+6", "ctrl+shift+7", "ctrl+shift+8", "ctrl+shift+9":
-		// Switch to sub-session by index
-		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-			idx := int(msg.String()[len(msg.String())-1] - '0')
-			activeTab.SetSubSessionByIndex(m.ptyManager, idx)
-			sessionID := activeTab.ResolveSessionID(m.ptyManager)
-			if sessionID != "" {
-				m.viewPTYSession(sessionID)
-			}
-		}
-		return m, nil
-
-	case "alt+z":
-		// Toggle session maximize for the active work tab
-		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
-			activeTab.SessionMaximized = !activeTab.SessionMaximized
-			if activeTab.SessionMaximized {
-				m.activePanel = PanelSession
-				// Wire session panel to the tab's active session
-				if sessionID := activeTab.ResolveSessionID(m.ptyManager); sessionID != "" {
-					m.viewPTYSession(sessionID)
-				}
-			} else {
-				m.activePanel = PanelWorkDetails
-			}
-			return m, nil
-		}
-		return m, nil
 
 	case "V":
 		m.beansExpanded = !m.beansExpanded
@@ -1750,15 +1688,94 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "alt+p":
-		// Spawn/resume planning session for selected bean (work details panel handles alt+p for Plan)
+	case "?":
+		m.viewMode = ViewHelp
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// handleAltKey handles alt+letter hotkeys for TUI actions.
+// Uses the letter code directly (e.g., 'n' for alt+n) since msg.String()
+// doesn't reliably include the alt modifier.
+func (m *planModel) handleAltKey(k rune) (*planModel, tea.Cmd) {
+	switch k {
+	case 'n':
+		// Create new bean inline
+		m.viewMode = ViewCreateBeanInline
+		m.beanFormPanel.Reset()
+		return m, m.beanFormPanel.Init()
+
+	case 'x':
+		// Close selected bean(s)
+		if len(m.beanItems) > 0 {
+			hasSelection := false
+			for _, item := range m.beanItems {
+				if m.selectedBeans[item.ID] {
+					hasSelection = true
+					break
+				}
+			}
+			if hasSelection || m.beansCursor < len(m.beanItems) {
+				m.viewMode = ViewCloseBeanConfirm
+			}
+		}
+		return m, nil
+
+	case 'd':
+		// Delete selected bean(s) permanently
+		if len(m.beanItems) > 0 {
+			hasSelection := false
+			for _, item := range m.beanItems {
+				if m.selectedBeans[item.ID] {
+					hasSelection = true
+					break
+				}
+			}
+			if hasSelection || m.beansCursor < len(m.beanItems) {
+				m.viewMode = ViewDeleteBeanConfirm
+			}
+		}
+		return m, nil
+
+	case 's':
+		// Cycle sort mode
+		switch m.filters.sortBy {
+		case "default":
+			m.filters.sortBy = "priority"
+		case "priority":
+			m.filters.sortBy = "title"
+		default:
+			m.filters.sortBy = "default"
+		}
+		return m, m.refreshData()
+
+	case 'z':
+		// Toggle session maximize for the active work tab
+		if activeTab := m.getActiveTab(); activeTab != nil && activeTab.Type == WorkTabWork {
+			activeTab.SessionMaximized = !activeTab.SessionMaximized
+			if activeTab.SessionMaximized {
+				m.activePanel = PanelSession
+				if sessionID := activeTab.ResolveSessionID(m.ptyManager); sessionID != "" {
+					m.viewPTYSession(sessionID)
+				}
+			} else {
+				m.activePanel = PanelWorkDetails
+			}
+			return m, nil
+		}
+		return m, nil
+
+	case 'p':
+		// Spawn/resume planning session for selected bean
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			beanID := m.beanItems[m.beansCursor].ID
 			return m, m.spawnPlanSession(beanID)
 		}
 		return m, nil
 
-	case "alt+w":
+	case 'w':
 		// Create work from cursor bean - show dialog
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1767,11 +1784,9 @@ handleNormalKeys:
 				m.statusIsError = true
 				return m, nil
 			}
-			// Generate proposed branch name from cursor bean
 			branchBeans := []*beansForBranch{{ID: bean.ID, Title: bean.Title}}
 			branchName := generateBranchNameFromBeansForBranch(branchBeans)
 			m.createWorkPanel.Reset(bean.ID, branchName)
-			// Load available branches for the "existing branch" mode
 			if branches, err := git.NewOperations().ListBranches(m.ctx, m.proj.MainRepoPath()); err == nil {
 				m.createWorkPanel.SetBranches(branches)
 			}
@@ -1780,7 +1795,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "alt+a":
+	case 'a':
 		// Add child issue to selected issue
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			parent := m.beanItems[m.beansCursor]
@@ -1795,7 +1810,7 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "alt+e":
+	case 'e':
 		// Edit selected issue using the unified bean form
 		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
 			bean := m.beanItems[m.beansCursor]
@@ -1805,16 +1820,8 @@ handleNormalKeys:
 		}
 		return m, nil
 
-	case "alt+shift+e":
-		// Edit selected issue in external editor
-		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
-			bean := m.beanItems[m.beansCursor]
-			return m, m.openInEditor(bean.ID)
-		}
-		return m, nil
-
-	case "alt+m":
-		// Import Linear issue inline - check for API key first
+	case 'm':
+		// Import Linear issue inline
 		var apiKey string
 		if m.proj.Config != nil {
 			apiKey = m.proj.Config.Linear.APIKey
@@ -1828,13 +1835,33 @@ handleNormalKeys:
 		m.linearImportPanel.Reset()
 		return m, m.linearImportPanel.Init()
 
-	case "alt+shift+m":
+	case 'q':
+		// Clean up resources before quitting
+		m.cleanup()
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+// handleAltShiftKey handles alt+shift+letter hotkeys for TUI actions.
+func (m *planModel) handleAltShiftKey(k rune) (*planModel, tea.Cmd) {
+	switch k {
+	case 'e':
+		// Edit selected issue in external editor
+		if len(m.beanItems) > 0 && m.beansCursor < len(m.beanItems) {
+			bean := m.beanItems[m.beansCursor]
+			return m, m.openInEditor(bean.ID)
+		}
+		return m, nil
+
+	case 'm':
 		// Import GitHub PR inline
 		m.viewMode = ViewPRImportInline
 		m.prImportPanel.Reset()
 		return m, m.prImportPanel.Init()
 
-	case "alt+shift+a":
+	case 'a':
 		// Add selected issue(s) to the focused work
 		if m.focusedWorkID == "" {
 			m.statusMessage = "Select a work first (press 1-9 to select a work)"
@@ -1842,13 +1869,11 @@ handleNormalKeys:
 			return m, nil
 		}
 		if len(m.beanItems) > 0 {
-			// Collect selected beans or use cursor bean
 			var beansToAdd []string
 			hasSelection := false
 			for _, item := range m.beanItems {
 				if m.selectedBeans[item.ID] {
 					hasSelection = true
-					// Check if already assigned
 					if item.assignedWorkID != "" {
 						m.statusMessage = fmt.Sprintf("Issue %s already assigned to %s", item.ID, item.assignedWorkID)
 						m.statusIsError = true
@@ -1857,8 +1882,6 @@ handleNormalKeys:
 					beansToAdd = append(beansToAdd, item.ID)
 				}
 			}
-
-			// If no selection, use cursor bean
 			if !hasSelection && m.beansCursor < len(m.beanItems) {
 				bean := m.beanItems[m.beansCursor]
 				if bean.assignedWorkID != "" {
@@ -1868,23 +1891,12 @@ handleNormalKeys:
 				}
 				beansToAdd = append(beansToAdd, bean.ID)
 			}
-
 			if len(beansToAdd) > 0 {
-				// Add issues directly to the focused work
-				m.selectedBeans = make(map[string]bool) // Clear selection after adding
+				m.selectedBeans = make(map[string]bool)
 				return m, m.addBeansToWork(beansToAdd, m.focusedWorkID)
 			}
 		}
 		return m, nil
-
-	case "?":
-		m.viewMode = ViewHelp
-		return m, nil
-
-	case "alt+q":
-		// Clean up resources before quitting
-		m.cleanup()
-		return m, tea.Quit
 	}
 
 	return m, nil

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -419,35 +419,35 @@ func (m *planModel) renderHelp() string {
 		}, "") + "\n" +
 
 		renderSection("Issue Management", [][]string{
-			entry("ctrl+n", "Create new issue"),
-			entry("ctrl+e", "Edit issue inline"),
-			entry("ctrl+shift+e", "Edit issue in $EDITOR"),
-			entry("ctrl+a", "Add child issue"),
-			entry("ctrl+x", "Close selected issue"),
-			entry("ctrl+d", "Delete issue (permanent)"),
+			entry("alt+n", "Create new issue"),
+			entry("alt+e", "Edit issue inline"),
+			entry("alt+shift+e", "Edit issue in $EDITOR"),
+			entry("alt+a", "Add child issue"),
+			entry("alt+x", "Close selected issue"),
+			entry("alt+d", "Delete issue (permanent)"),
 			entry("Space", "Toggle multi-select"),
-			entry("ctrl+w", "Create work from issue(s)"),
-			entry("ctrl+shift+a", "Add issue to focused work"),
-			entry("ctrl+m", "Import from Linear"),
-			entry("ctrl+shift+m", "Import from GitHub PR"),
-			entry("ctrl+p", "Start/Resume planning"),
-		}, "All action keys use ctrl+ prefix.\nctrl+key combos work from any panel,\nincluding active pi sessions.")
+			entry("alt+w", "Create work from issue(s)"),
+			entry("alt+shift+a", "Add issue to focused work"),
+			entry("alt+m", "Import from Linear"),
+			entry("alt+shift+m", "Import from GitHub PR"),
+			entry("alt+p", "Start/Resume planning"),
+		}, "All action keys use alt/⌥ prefix to avoid\nconflicting with pi session hotkeys.\nalt+key combos work from any panel,\nincluding active pi sessions.")
 
 	rightCol := "\n\n" +
 		renderSection("Work Actions", [][]string{
-			entry("ctrl+t", "Open terminal/console"),
-			entry("ctrl+c", "Open agent chat"),
-			entry("ctrl+i", "Open IDE"),
-			entry("ctrl+r", "Run work"),
-			entry("ctrl+o", "Restart orchestrator"),
-			entry("ctrl+v", "Create review task"),
-			entry("ctrl+p", "Create PR / plan session"),
-			entry("ctrl+f", "Check PR feedback"),
-			entry("ctrl+d", "Destroy work / Delete issue"),
-			entry("ctrl+x", "Reset failed task"),
-			entry("ctrl+a", "Add child issue to work"),
-			entry("ctrl+g", "Pick session to view"),
-		}, "Panel-aware: ctrl+d changes behavior based on\nfocused panel. Work actions are available\nwhen a work is selected.") + "\n" +
+			entry("alt+t", "Open terminal/console"),
+			entry("alt+c", "Open agent chat"),
+			entry("alt+i", "Open IDE"),
+			entry("alt+r", "Run work"),
+			entry("alt+o", "Restart orchestrator"),
+			entry("alt+v", "Create review task"),
+			entry("alt+p", "Create PR / plan session"),
+			entry("alt+f", "Check PR feedback"),
+			entry("alt+d", "Destroy work / Delete issue"),
+			entry("alt+x", "Reset failed task"),
+			entry("alt+a", "Add child issue to work"),
+			entry("alt+g", "Pick session to view"),
+		}, "Panel-aware: alt+d changes behavior based on\nfocused panel. Work actions are available\nwhen a work is selected.") + "\n" +
 
 		renderSection("Filters", [][]string{
 			entry("O", "Show open issues"),
@@ -456,17 +456,17 @@ func (m *planModel) renderHelp() string {
 			entry("V", "Toggle expanded view"),
 			entry("/", "Fuzzy search"),
 			entry("L", "Filter by label"),
-			entry("ctrl+s", "Cycle sort mode"),
+			entry("alt+s", "Cycle sort mode"),
 			entry("*", "Show all (clear filters)"),
 		}, "") + "\n" +
 
 		renderSection("Sessions & Tabs", [][]string{
-			entry("ctrl+z", "Maximize/restore session"),
+			entry("alt+z", "Maximize/restore session"),
 			entry("ctrl+shift+1-9", "Switch sub-session"),
 			entry("Tab", "Cycle panels (details→session→issues)"),
 			entry("esc", "Exit session / deselect work"),
 			entry("1-9", "Select work tab"),
-		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with ctrl+p on a bean.") + "\n" +
+		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with alt+p on a bean.") + "\n" +
 
 		renderSection("Indicators", [][]string{
 			entry("●", "Multi-selected"),

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -419,35 +419,35 @@ func (m *planModel) renderHelp() string {
 		}, "") + "\n" +
 
 		renderSection("Issue Management", [][]string{
-			entry("n", "Create new issue"),
-			entry("e", "Edit issue inline"),
-			entry("E", "Edit issue in $EDITOR"),
-			entry("a", "Add child issue"),
-			entry("x", "Close selected issue"),
-			entry("d", "Delete issue (permanent)"),
+			entry("ctrl+n", "Create new issue"),
+			entry("ctrl+e", "Edit issue inline"),
+			entry("ctrl+shift+e", "Edit issue in $EDITOR"),
+			entry("ctrl+a", "Add child issue"),
+			entry("ctrl+x", "Close selected issue"),
+			entry("ctrl+d", "Delete issue (permanent)"),
 			entry("Space", "Toggle multi-select"),
-			entry("w", "Create work from issue(s)"),
-			entry("A", "Add issue to focused work"),
-			entry("m", "Import from Linear"),
-			entry("M", "Import from GitHub PR"),
-			entry("p", "Start/Resume planning"),
-		}, "")
+			entry("ctrl+w", "Create work from issue(s)"),
+			entry("ctrl+shift+a", "Add issue to focused work"),
+			entry("ctrl+m", "Import from Linear"),
+			entry("ctrl+shift+m", "Import from GitHub PR"),
+			entry("ctrl+p", "Start/Resume planning"),
+		}, "All action keys use ctrl+ prefix.\nctrl+key combos work from any panel,\nincluding active pi sessions.")
 
 	rightCol := "\n\n" +
 		renderSection("Work Actions", [][]string{
-			entry("t", "Open terminal/console"),
-			entry("c", "Open agent chat"),
-			entry("i", "Open IDE"),
-			entry("r", "Run work"),
-			entry("o", "Restart orchestrator"),
-			entry("v", "Create review task"),
-			entry("p", "Create PR / plan session"),
-			entry("f", "Check PR feedback"),
-			entry("d", "Destroy work / Delete issue"),
-			entry("x", "Reset failed task"),
-			entry("a", "Add child issue to work"),
-			entry("g", "Pick session to view"),
-		}, "Panel-aware: d changes behavior based on\nfocused panel. t/c/i/r/o/v/f/g are exclusively\nwork actions when a work is selected.") + "\n" +
+			entry("ctrl+t", "Open terminal/console"),
+			entry("ctrl+c", "Open agent chat"),
+			entry("ctrl+i", "Open IDE"),
+			entry("ctrl+r", "Run work"),
+			entry("ctrl+o", "Restart orchestrator"),
+			entry("ctrl+v", "Create review task"),
+			entry("ctrl+p", "Create PR / plan session"),
+			entry("ctrl+f", "Check PR feedback"),
+			entry("ctrl+d", "Destroy work / Delete issue"),
+			entry("ctrl+x", "Reset failed task"),
+			entry("ctrl+a", "Add child issue to work"),
+			entry("ctrl+g", "Pick session to view"),
+		}, "Panel-aware: ctrl+d changes behavior based on\nfocused panel. Work actions are available\nwhen a work is selected.") + "\n" +
 
 		renderSection("Filters", [][]string{
 			entry("O", "Show open issues"),
@@ -456,17 +456,17 @@ func (m *planModel) renderHelp() string {
 			entry("V", "Toggle expanded view"),
 			entry("/", "Fuzzy search"),
 			entry("L", "Filter by label"),
-			entry("s", "Cycle sort mode"),
+			entry("ctrl+s", "Cycle sort mode"),
 			entry("*", "Show all (clear filters)"),
 		}, "") + "\n" +
 
 		renderSection("Sessions & Tabs", [][]string{
-			entry("z", "Maximize/restore session"),
-			entry("ctrl+1/2/3", "Switch agent/console/plan"),
+			entry("ctrl+z", "Maximize/restore session"),
+			entry("ctrl+shift+1-9", "Switch sub-session"),
 			entry("Tab", "Cycle panels (details→session→issues)"),
 			entry("esc", "Exit session / deselect work"),
 			entry("1-9", "Select work tab"),
-		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with [p] on a bean.") + "\n" +
+		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with ctrl+p on a bean.") + "\n" +
 
 		renderSection("Indicators", [][]string{
 			entry("●", "Multi-selected"),

--- a/internal/tui/tui_plan_render.go
+++ b/internal/tui/tui_plan_render.go
@@ -419,35 +419,35 @@ func (m *planModel) renderHelp() string {
 		}, "") + "\n" +
 
 		renderSection("Issue Management", [][]string{
-			entry("alt+n", "Create new issue"),
-			entry("alt+e", "Edit issue inline"),
-			entry("alt+shift+e", "Edit issue in $EDITOR"),
-			entry("alt+a", "Add child issue"),
-			entry("alt+x", "Close selected issue"),
-			entry("alt+d", "Delete issue (permanent)"),
+			entry("ctrl+n", "Create new issue"),
+			entry("ctrl+e", "Edit issue inline"),
+			entry("ctrl+shift+e", "Edit issue in $EDITOR"),
+			entry("ctrl+a", "Add child issue"),
+			entry("ctrl+x", "Close selected issue"),
+			entry("ctrl+d", "Delete issue (permanent)"),
 			entry("Space", "Toggle multi-select"),
-			entry("alt+w", "Create work from issue(s)"),
-			entry("alt+shift+a", "Add issue to focused work"),
-			entry("alt+m", "Import from Linear"),
-			entry("alt+shift+m", "Import from GitHub PR"),
-			entry("alt+p", "Start/Resume planning"),
-		}, "All action keys use alt/⌥ prefix to avoid\nconflicting with pi session hotkeys.\nalt+key combos work from any panel,\nincluding active pi sessions.")
+			entry("ctrl+w", "Create work from issue(s)"),
+			entry("ctrl+shift+a", "Add issue to focused work"),
+			entry("ctrl+m", "Import from Linear"),
+			entry("ctrl+shift+m", "Import from GitHub PR"),
+			entry("ctrl+p", "Start/Resume planning"),
+		}, "All action keys use ctrl+ prefix.\nWhen a pi session is focused, only ESC\nexits — all keys go to the session.")
 
 	rightCol := "\n\n" +
 		renderSection("Work Actions", [][]string{
-			entry("alt+t", "Open terminal/console"),
-			entry("alt+c", "Open agent chat"),
-			entry("alt+i", "Open IDE"),
-			entry("alt+r", "Run work"),
-			entry("alt+o", "Restart orchestrator"),
-			entry("alt+v", "Create review task"),
-			entry("alt+p", "Create PR / plan session"),
-			entry("alt+f", "Check PR feedback"),
-			entry("alt+d", "Destroy work / Delete issue"),
-			entry("alt+x", "Reset failed task"),
-			entry("alt+a", "Add child issue to work"),
-			entry("alt+g", "Pick session to view"),
-		}, "Panel-aware: alt+d changes behavior based on\nfocused panel. Work actions are available\nwhen a work is selected.") + "\n" +
+			entry("ctrl+t", "Open terminal/console"),
+			entry("ctrl+c", "Open agent chat"),
+			entry("ctrl+i", "Open IDE"),
+			entry("ctrl+r", "Run work"),
+			entry("ctrl+o", "Restart orchestrator"),
+			entry("ctrl+v", "Create review task"),
+			entry("ctrl+p", "Create PR / plan session"),
+			entry("ctrl+f", "Check PR feedback"),
+			entry("ctrl+d", "Destroy work / Delete issue"),
+			entry("ctrl+x", "Reset failed task"),
+			entry("ctrl+a", "Add child issue to work"),
+			entry("ctrl+g", "Pick session to view"),
+		}, "Panel-aware: ctrl+d changes behavior based on\nfocused panel. Work actions are available\nwhen a work is selected.") + "\n" +
 
 		renderSection("Filters", [][]string{
 			entry("O", "Show open issues"),
@@ -456,17 +456,17 @@ func (m *planModel) renderHelp() string {
 			entry("V", "Toggle expanded view"),
 			entry("/", "Fuzzy search"),
 			entry("L", "Filter by label"),
-			entry("alt+s", "Cycle sort mode"),
+			entry("ctrl+s", "Cycle sort mode"),
 			entry("*", "Show all (clear filters)"),
 		}, "") + "\n" +
 
 		renderSection("Sessions & Tabs", [][]string{
-			entry("alt+z", "Maximize/restore session"),
+			entry("ctrl+z", "Maximize/restore session"),
 			entry("ctrl+shift+1-9", "Switch sub-session"),
 			entry("Tab", "Cycle panels (details→session→issues)"),
 			entry("esc", "Exit session / deselect work"),
 			entry("1-9", "Select work tab"),
-		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with alt+p on a bean.") + "\n" +
+		}, "Main tab: always-present pi session.\nWork tabs: details + embedded session.\nPlan tabs: created with ctrl+p on a bean.") + "\n" +
 
 		renderSection("Indicators", [][]string{
 			entry("●", "Multi-selected"),

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -115,8 +115,7 @@ func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Global keys (only when not in modal)
-		switch msg.String() {
-		case "alt+q":
+		if altKey(msg) == 'q' {
 			m.quitting = true
 			// Clean up resources in plan model
 			if m.planModel != nil {

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -116,7 +116,7 @@ func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Global keys (only when not in modal)
 		switch msg.String() {
-		case "q":
+		case "ctrl+q":
 			m.quitting = true
 			// Clean up resources in plan model
 			if m.planModel != nil {

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -115,7 +115,7 @@ func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Global keys (only when not in modal)
-		if altKey(msg) == 'q' {
+		if ctrlKey(msg) == 'q' {
 			m.quitting = true
 			// Clean up resources in plan model
 			if m.planModel != nil {

--- a/internal/tui/tui_root.go
+++ b/internal/tui/tui_root.go
@@ -116,7 +116,7 @@ func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Global keys (only when not in modal)
 		switch msg.String() {
-		case "ctrl+q":
+		case "alt+q":
 			m.quitting = true
 			// Clean up resources in plan model
 			if m.planModel != nil {

--- a/internal/tui/tui_shared.go
+++ b/internal/tui/tui_shared.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/sargehq/sarge/internal/beans"
 	"github.com/sargehq/sarge/internal/db"
@@ -242,6 +243,35 @@ func styleHotkeys(text string) string {
 		i++
 	}
 	return result.String()
+}
+
+// altKey extracts the alt+key letter from a KeyPressMsg.
+// Returns the lowercase letter (e.g., 'n' for alt+n) if alt is held
+// without ctrl, or 0 if not an alt+letter combo.
+// Use altShiftKey for alt+shift combos.
+func altKey(msg tea.KeyPressMsg) rune {
+	if msg.Mod&tea.ModAlt == 0 || msg.Mod&tea.ModCtrl != 0 {
+		return 0
+	}
+	if msg.Mod&tea.ModShift != 0 {
+		return 0 // alt+shift handled separately
+	}
+	if msg.Code >= 'a' && msg.Code <= 'z' {
+		return msg.Code
+	}
+	return 0
+}
+
+// altShiftKey extracts the alt+shift+key letter from a KeyPressMsg.
+// Returns the lowercase letter (e.g., 'e' for alt+shift+e) if alt+shift is held, or 0.
+func altShiftKey(msg tea.KeyPressMsg) rune {
+	if msg.Mod&tea.ModAlt == 0 || msg.Mod&tea.ModShift == 0 || msg.Mod&tea.ModCtrl != 0 {
+		return 0
+	}
+	if msg.Code >= 'a' && msg.Code <= 'z' {
+		return msg.Code
+	}
+	return 0
 }
 
 // styleButtonWithHover styles a button with hover effect if hovered is true

--- a/internal/tui/tui_shared.go
+++ b/internal/tui/tui_shared.go
@@ -245,16 +245,16 @@ func styleHotkeys(text string) string {
 	return result.String()
 }
 
-// altKey extracts the alt+key letter from a KeyPressMsg.
-// Returns the lowercase letter (e.g., 'n' for alt+n) if alt is held
-// without ctrl, or 0 if not an alt+letter combo.
-// Use altShiftKey for alt+shift combos.
-func altKey(msg tea.KeyPressMsg) rune {
-	if msg.Mod&tea.ModAlt == 0 || msg.Mod&tea.ModCtrl != 0 {
+// ctrlKey extracts the ctrl+key letter from a KeyPressMsg.
+// Returns the lowercase letter (e.g., 'n' for ctrl+n) if ctrl is held
+// without alt, or 0 if not a ctrl+letter combo.
+// Use ctrlShiftKey for ctrl+shift combos.
+func ctrlKey(msg tea.KeyPressMsg) rune {
+	if msg.Mod&tea.ModCtrl == 0 || msg.Mod&tea.ModAlt != 0 {
 		return 0
 	}
 	if msg.Mod&tea.ModShift != 0 {
-		return 0 // alt+shift handled separately
+		return 0 // ctrl+shift handled separately
 	}
 	if msg.Code >= 'a' && msg.Code <= 'z' {
 		return msg.Code
@@ -262,10 +262,10 @@ func altKey(msg tea.KeyPressMsg) rune {
 	return 0
 }
 
-// altShiftKey extracts the alt+shift+key letter from a KeyPressMsg.
-// Returns the lowercase letter (e.g., 'e' for alt+shift+e) if alt+shift is held, or 0.
-func altShiftKey(msg tea.KeyPressMsg) rune {
-	if msg.Mod&tea.ModAlt == 0 || msg.Mod&tea.ModShift == 0 || msg.Mod&tea.ModCtrl != 0 {
+// ctrlShiftKey extracts the ctrl+shift+key letter from a KeyPressMsg.
+// Returns the lowercase letter (e.g., 'e' for ctrl+shift+e) if ctrl+shift is held, or 0.
+func ctrlShiftKey(msg tea.KeyPressMsg) rune {
+	if msg.Mod&tea.ModCtrl == 0 || msg.Mod&tea.ModShift == 0 || msg.Mod&tea.ModAlt != 0 {
 		return 0
 	}
 	if msg.Code >= 'a' && msg.Code <= 'z' {


### PR DESCRIPTION
## Summary

All TUI action hotkeys now use **ctrl+key**. When a pi session panel is focused, **only ESC exits** — all other keys (including ctrl) go to the PTY, giving pi complete keyboard control.

## Design

- **Session focused:** ESC exits → everything else passes through to pi
- **Any other panel focused:** ctrl+key triggers TUI actions (no conflict since pi isn't receiving input)

## Key mapping

| Action | Key | Action | Key |
|--------|-----|--------|-----|
| New bean | ctrl+n | Terminal | ctrl+t |
| Edit | ctrl+e | Chat/agent | ctrl+c |
| Add child | ctrl+a | IDE | ctrl+i |
| Close | ctrl+x | Run | ctrl+r |
| Delete | ctrl+d | Orchestrator | ctrl+o |
| Create work | ctrl+w | Review | ctrl+v |
| Plan | ctrl+p | Feedback | ctrl+f |
| Sort | ctrl+s | Session picker | ctrl+g |
| Maximize | ctrl+z | Quit | ctrl+q |
| Import Linear | ctrl+m | Edit in $EDITOR | ctrl+shift+e |
| Import PR | ctrl+shift+m | Add to work | ctrl+shift+a |

**Unchanged:** j/k/arrows (nav), tab (cycle), 1-9 (tabs), space (select), esc, O/C/R/V/L (filters), / (search), ? (help), \[ \] (resize)

## Why not alt/option or cmd?

Tested with a keytest tool on macOS:
- **alt/option** → produces dead keys (˜, ´), `ModAlt` never set — unusable
- **cmd/super** → intercepted by terminal emulator (cmd+n = new window) — unusable
- **ctrl+key** → `ModCtrl=true`, proper key codes — works perfectly

## Implementation

- `ctrlKey()` / `ctrlShiftKey()` helpers check `msg.Mod` and `msg.Code` directly (not `msg.String()` which is unreliable for modified keys)
- Extracted `handleCtrlKey()`, `handleCtrlShiftKey()`, `handleCtrlAction()` methods
- Status bar uses `^` prefix notation (e.g. `^[n]ew ^[e]dit`)