### PR TITLE
feat: add nix flake for installation on nix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,54 @@ This downloads the latest release for your platform. Alternatively:
 go install github.com/sargehq/sarge@latest
 ```
 
+### Nix
+
+Sarge ships a `flake.nix`. Run it directly without installing:
+
+```bash
+nix run github:sargehq/sarge
+```
+
+Install into your profile:
+
+```bash
+nix profile install github:sargehq/sarge
+```
+
+Use it in your own flake by adding sarge as an input:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    sarge.url = "github:sargehq/sarge";
+  };
+
+  outputs = { self, nixpkgs, sarge, ... }:
+    let
+      system = "x86_64-linux"; # or "aarch64-linux", "x86_64-darwin", "aarch64-darwin"
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      # Add sarge to a NixOS system
+      nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ({ pkgs, ... }: {
+            environment.systemPackages = [
+              sarge.packages.${system}.default
+            ];
+          })
+        ];
+      };
+
+      # Or use in a devShell
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [ sarge.packages.${system}.default ];
+      };
+    };
+}
+```
+
 For more information, visit [sargehq.dev](https://sargehq.dev).
 
 ## Quick Start

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773282481,
+        "narHash": "sha256-b/GV2ysM8mKHhinse2wz+uP37epUrSE+sAKXy/xvBY4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe416aaedd397cacb33a610b33d60ff2b431b127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Sarge - Orchestrate code agents to process issues and create PRs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = self.shortRev or self.dirtyShortRev or "unknown";
+      in
+      {
+        packages = {
+          sarge = pkgs.buildGoModule {
+            pname = "sarge";
+            inherit version;
+            src = self;
+
+            vendorHash = "sha256-R8KJZRt0lAb+fd4dHpsKbrsDhO5M682boVMY+g4WIrQ=";
+
+            env.CGO_ENABLED = "0";
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${version}"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Orchestrate code agents to process issues and create PRs";
+              homepage = "https://github.com/sargehq/sarge";
+              license = licenses.asl20;
+              mainProgram = "sarge";
+              platforms = platforms.unix;
+            };
+          };
+
+          default = self.packages.${system}.sarge;
+        };
+
+        apps = {
+          sarge = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.sarge;
+          };
+          default = self.apps.${system}.sarge;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `flake.nix` and `flake.lock` so sarge can be installed on Nix systems
- Documents Nix installation options in README (`nix run`, `nix profile install`, flake input)

## Test plan

- [x] `nix run github:sargehq/sarge` runs the binary
- [x] `nix profile install github:sargehq/sarge` installs successfully
- [x] Flake input example in README is correct
- [ ] Update `vendorHash` in `flake.nix` whenever `go.mod`/`go.sum` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)