### PR TITLE
Clean up legacy co references and fix go install

### DIFF
--- a/internal/control/spawn.go
+++ b/internal/control/spawn.go
@@ -18,7 +18,7 @@ const ControlPlaneTabName = "control"
 type InitResult struct {
 	// SessionCreated is true if a new zellij session was created
 	SessionCreated bool
-	// SessionName is the name of the zellij session (e.g., "co-myproject")
+	// SessionName is the name of the zellij session (e.g., "sarge-myproject")
 	SessionName string
 }
 

--- a/internal/github/client_comment_test.go
+++ b/internal/github/client_comment_test.go
@@ -26,7 +26,7 @@ func TestPostPRComment(t *testing.T) {
 	ctx := context.Background()
 
 	// Test posting a simple comment
-	err := client.PostPRComment(ctx, prURL, "Test comment from co integration test")
+	err := client.PostPRComment(ctx, prURL, "Test comment from sarge integration test")
 	require.NoError(t, err, "Failed to post PR comment")
 
 	t.Log("Successfully posted PR comment")
@@ -51,7 +51,7 @@ func TestPostReplyToComment(t *testing.T) {
 	ctx := context.Background()
 
 	// Test posting a reply to a comment
-	err := client.PostReplyToComment(ctx, prURL, commentID, "Test reply from co integration test")
+	err := client.PostReplyToComment(ctx, prURL, commentID, "Test reply from sarge integration test")
 	require.NoError(t, err, "Failed to post reply to comment")
 
 	t.Log("Successfully posted reply to comment")

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -324,7 +324,7 @@ func setupMise(projectRoot, mainPath string, toolSelections mise.ToolSelections)
 	if err := mise.GenerateConfigWithSelections(projectRoot, toolSelections); err != nil {
 		fmt.Printf("Warning: failed to generate mise config: %v\n", err)
 	} else {
-		fmt.Printf("Mise: generated .mise.toml with co requirements\n")
+		fmt.Printf("Mise: generated .mise.toml with sarge requirements\n")
 	}
 
 	// Initialize mise in project root (optional - warn on error)

--- a/internal/testutil/integration_test.go
+++ b/internal/testutil/integration_test.go
@@ -76,7 +76,7 @@ func TestWorkLifecycleFlow_SingleTask(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the work
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err = h.DB.GetWork(ctx, workID)
@@ -175,7 +175,7 @@ func TestWorkLifecycleFlow_MultipleTasksWithDependencies(t *testing.T) {
 	// Phase 4: Execute tasks in sequence
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err := h.DB.GetWork(ctx, workID)
@@ -250,7 +250,7 @@ func TestWorkLifecycleFlow_EpicExpansion(t *testing.T) {
 	// Phase 4: Execute and complete
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err := h.DB.GetWork(ctx, workID)
@@ -300,7 +300,7 @@ func TestPRFeedbackFlow_FeedbackBeansAddedToWork(t *testing.T) {
 	// Set up work for execution
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	// Create and complete initial task
@@ -452,7 +452,7 @@ func TestReviewIterationFlow_FullCycle(t *testing.T) {
 	// Set up work for execution
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err := h.DB.GetWork(ctx, workID)
@@ -578,7 +578,7 @@ func TestReviewIterationFlow_MaxIterationsForcesPR(t *testing.T) {
 
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err := h.DB.GetWork(ctx, workID)
@@ -800,7 +800,7 @@ func TestWorkLifecycleFlow_TaskFailureAndRecovery(t *testing.T) {
 
 	err = h.DB.UpdateWorkWorktreePath(ctx, workID, "/test/project/"+workID+"/tree")
 	require.NoError(t, err)
-	err = h.DB.StartWork(ctx, workID, "co-test-session", "tab-1")
+	err = h.DB.StartWork(ctx, workID, "sarge-test-session", "tab-1")
 	require.NoError(t, err)
 
 	workRecord, err := h.DB.GetWork(ctx, workID)

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -945,7 +945,7 @@ type planSessionSpawnedMsg struct {
 	resumed        bool
 	err            error
 	sessionCreated bool   // true if a new zellij session was created
-	sessionName    string // e.g., 'co-myproject'
+	sessionName    string // e.g., 'sarge-myproject'
 }
 
 // planWorkCreatedMsg indicates work was created from a bean
@@ -954,7 +954,7 @@ type planWorkCreatedMsg struct {
 	workID         string
 	err            error
 	sessionCreated bool   // true if a new zellij session was created
-	sessionName    string // e.g., 'co-myproject'
+	sessionName    string // e.g., 'sarge-myproject'
 }
 
 // beanAddedToWorkMsg indicates a bean was added to a work


### PR DESCRIPTION
## Summary

- Replace 13 stale references to the old project name "co" with "sarge" across comments, user-facing strings, and test fixtures
- Fix `go install github.com/sargehq/sarge@latest` and `scripts/install.sh` failures caused by stale tags

### Tag fix (already applied, no code changes)

`go install` and the install script were both broken:

1. **Install script**: `install_from_release` returned 404 because no GitHub Release existed
2. **`go install` fallback**: resolved to `v0.1.0-alpha.3`, which still had `module github.com/newhook/co` in `go.mod`, causing a module path mismatch error

To fix this:

1. Deleted stale remote and local tags `v0.1.0-alpha.1`, `v0.1.0-alpha.2`, `v0.1.0-alpha.3`
2. Created and pushed `v0.1.0-alpha.4` on current `main`, which triggered the release workflow (`.github/workflows/release.yml`) for the first time
3. GoReleaser published cross-compiled binaries (linux/darwin × amd64/arm64) as a GitHub Release

Both `go install github.com/sargehq/sarge@latest` and `curl | bash` install paths now work.

### Code changes

| File | What changed |
|------|-------------|
| `internal/control/spawn.go` | Comment: `co-myproject` → `sarge-myproject` |
| `internal/tui/tui_plan.go` | Comments (2x): `co-myproject` → `sarge-myproject` |
| `internal/project/project.go` | User-facing print: "co requirements" → "sarge requirements" |
| `internal/testutil/integration_test.go` | Test fixtures (7x): `co-test-session` → `sarge-test-session` |
| `internal/github/client_comment_test.go` | Test fixtures (2x): "co integration test" → "sarge integration test" |