### PR TITLE
Rename .co config directory to .sarge with auto-migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,9 @@ if exitErr, ok := err.(*exec.ExitError); ok {  // Don't do this
 
 The project uses Go's `slog` for structured debug logging via `internal/logging`.
 
-- Logs are written to `.co/debug.log` in JSON format (append mode)
+- Logs are written to `.sarge/debug.log` in JSON format (append mode)
 - Logging is automatically initialized when a project is loaded
-- Log file location: `<project-root>/.co/debug.log`
+- Log file location: `<project-root>/.sarge/debug.log`
 
 ### Usage
 
@@ -128,10 +128,10 @@ logger.With("component", "beans").Debug("message")
 
 ```bash
 # View recent logs
-tail -f .co/debug.log
+tail -f .sarge/debug.log
 
 # Pretty-print JSON logs
-cat .co/debug.log | jq .
+cat .sarge/debug.log | jq .
 ```
 
 ## Mock Generation
@@ -394,7 +394,7 @@ When enabled, Claude analyzes CI logs directly and creates beans for each failur
 - Creates beans with appropriate priorities (P0-P3)
 - Works with complex, multi-line error messages
 
-Enable in `.co/config.toml`:
+Enable in `.sarge/config.toml`:
 
 ```toml
 [log_parser]
@@ -452,7 +452,7 @@ All commands require a project context. Projects are created with `sarge proj cr
 
 ```
 <project-dir>/
-├── .co/
+├── .sarge/
 │   ├── config.toml      # Project configuration
 │   ├── tracking.db      # SQLite coordination database
 │   └── .beans/          # beans (if project-local)
@@ -464,7 +464,7 @@ All commands require a project context. Projects are created with `sarge proj cr
 
 beans location is determined at project creation:
 - **Repo beans** (`main/.beans/`): Used when the repository already has beans initialized. Git hooks are installed for sync.
-- **Project-local beans** (`.co/.beans/`): Used when the repository doesn't have beans. No hooks or sync (standalone).
+- **Project-local beans** (`.sarge/.beans/`): Used when the repository doesn't have beans. No hooks or sync (standalone).
 
 ## Work Concept (3-Tier Hierarchy)
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ These commands must be used via CLI (not available in TUI):
 
 ```
 <project-dir>/
-├── .co/
+├── .sarge/
 │   ├── config.toml      # Project configuration
 │   └── tracking.db      # SQLite coordination database
 ├── main/                # Symlink to local repo OR clone from GitHub

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sargehq/sarge/internal/agentsetup"
 	"github.com/sargehq/sarge/internal/mise"
@@ -24,6 +26,7 @@ Checks include:
   - Mise beans version: ensures the mise config has the correct beans version
   - Beans integration: ensures the coding agent has beans support configured
   - Sarge extension (pi): ensures the sarge-complete extension is installed
+  - Beads hooks: detects and removes legacy beads (bd) git hooks
 
 Use --dry-run to preview changes without applying them.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -76,6 +79,13 @@ func runDoctor(proj *project.Project) error {
 		return fmt.Errorf("pi extension check failed: %w", err)
 	}
 	issues += extIssues
+
+	// Check 5: Legacy beads git hooks
+	hookIssues, err := checkBeadsHooks(proj)
+	if err != nil {
+		return fmt.Errorf("beads hooks check failed: %w", err)
+	}
+	issues += hookIssues
 
 	// Summary
 	fmt.Println()
@@ -253,6 +263,75 @@ func checkPiExtension(proj *project.Project) (int, error) {
 	}
 	fmt.Println("🧩 Sarge extension (pi): installed .pi/extensions/sarge-complete.ts in main repo")
 	return 1, nil
+}
+
+// beadsShimMarker is the sentinel string present in all beads hook shims.
+const beadsShimMarker = "# bd-shim v1"
+
+// beadsHookNames lists git hook files that beads (bd) may have installed.
+var beadsHookNames = []string{
+	"post-checkout",
+	"post-merge",
+	"pre-commit",
+	"prepare-commit-msg",
+	"pre-push",
+}
+
+func checkBeadsHooks(proj *project.Project) (int, error) {
+	hooksDir := filepath.Join(proj.MainRepoPath(), ".git", "hooks")
+	return checkBeadsHooksInDir(hooksDir)
+}
+
+// checkBeadsHooksInDir scans hooksDir for legacy beads hook shims and
+// removes them (or reports them in dry-run mode).
+func checkBeadsHooksInDir(hooksDir string) (int, error) {
+	if _, err := os.Stat(hooksDir); os.IsNotExist(err) {
+		fmt.Println("🪝 Beads hooks: no hooks directory")
+		return 0, nil
+	}
+
+	var found []string
+	for _, name := range beadsHookNames {
+		hookPath := filepath.Join(hooksDir, name)
+		if isBeadsHook(hookPath) {
+			found = append(found, name)
+		}
+	}
+
+	if len(found) == 0 {
+		fmt.Println("🪝 Beads hooks: none found")
+		return 0, nil
+	}
+
+	if doctorDryRun {
+		fmt.Println("🪝 Beads hooks: legacy beads hooks detected")
+		for _, name := range found {
+			fmt.Printf("   %s (would be removed)\n", name)
+		}
+		return 1, nil
+	}
+
+	// Remove the beads hook files
+	for _, name := range found {
+		hookPath := filepath.Join(hooksDir, name)
+		if err := os.Remove(hookPath); err != nil {
+			return 0, fmt.Errorf("failed to remove beads hook %s: %w", name, err)
+		}
+	}
+	fmt.Println("🪝 Beads hooks: removed legacy hooks")
+	for _, name := range found {
+		fmt.Printf("   - %s\n", name)
+	}
+	return 1, nil
+}
+
+// isBeadsHook returns true if the file at path contains the beads shim marker.
+func isBeadsHook(path string) bool {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), beadsShimMarker)
 }
 
 func checkConfigApply(configPath string, cfg *project.Config) (int, error) {

--- a/cmd/doctor_hooks_test.go
+++ b/cmd/doctor_hooks_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const beadsPostCheckoutHook = `#!/usr/bin/env bash
+# bd-shim v1
+# bd-hooks-version: abc123
+exec bd hook post-checkout "$@"
+`
+
+const beadsPrepareMsgHook = `#!/usr/bin/env bash
+# bd-shim v1
+# bd-hooks-version: abc123
+exec bd hooks run prepare-commit-msg "$@"
+`
+
+const nonBeadsHook = `#!/usr/bin/env bash
+# Custom hook for CI checks
+echo "Running lint..."
+npm run lint
+`
+
+func writeHook(t *testing.T, dir, name, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o755)
+	require.NoError(t, err)
+}
+
+func TestCheckBeadsHooksInDir_NoHooksDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nonexistent")
+	issues, err := checkBeadsHooksInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, issues)
+}
+
+func TestCheckBeadsHooksInDir_NoBeadsHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeHook(t, dir, "pre-commit", nonBeadsHook)
+	writeHook(t, dir, "post-merge", nonBeadsHook)
+
+	issues, err := checkBeadsHooksInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, issues)
+}
+
+func TestCheckBeadsHooksInDir_ApplyRemovesBeadsHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeHook(t, dir, "post-checkout", beadsPostCheckoutHook)
+	writeHook(t, dir, "prepare-commit-msg", beadsPrepareMsgHook)
+
+	// Ensure apply mode (not dry-run)
+	oldDryRun := doctorDryRun
+	doctorDryRun = false
+	defer func() { doctorDryRun = oldDryRun }()
+
+	issues, err := checkBeadsHooksInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, issues)
+
+	// Both files should be removed
+	_, err = os.Stat(filepath.Join(dir, "post-checkout"))
+	assert.True(t, os.IsNotExist(err), "post-checkout should be removed")
+	_, err = os.Stat(filepath.Join(dir, "prepare-commit-msg"))
+	assert.True(t, os.IsNotExist(err), "prepare-commit-msg should be removed")
+}
+
+func TestCheckBeadsHooksInDir_DryRunDoesNotRemove(t *testing.T) {
+	dir := t.TempDir()
+	writeHook(t, dir, "post-checkout", beadsPostCheckoutHook)
+
+	oldDryRun := doctorDryRun
+	doctorDryRun = true
+	defer func() { doctorDryRun = oldDryRun }()
+
+	issues, err := checkBeadsHooksInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, issues)
+
+	// File should still exist
+	_, err = os.Stat(filepath.Join(dir, "post-checkout"))
+	assert.NoError(t, err, "post-checkout should NOT be removed in dry-run")
+}
+
+func TestCheckBeadsHooksInDir_MixedHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeHook(t, dir, "post-checkout", beadsPostCheckoutHook)
+	writeHook(t, dir, "pre-commit", nonBeadsHook)
+
+	oldDryRun := doctorDryRun
+	doctorDryRun = false
+	defer func() { doctorDryRun = oldDryRun }()
+
+	issues, err := checkBeadsHooksInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, issues)
+
+	// Beads hook removed
+	_, err = os.Stat(filepath.Join(dir, "post-checkout"))
+	assert.True(t, os.IsNotExist(err), "beads hook should be removed")
+
+	// Non-beads hook preserved
+	_, err = os.Stat(filepath.Join(dir, "pre-commit"))
+	assert.NoError(t, err, "non-beads hook should be preserved")
+}
+
+func TestIsBeadsHook(t *testing.T) {
+	dir := t.TempDir()
+
+	writeHook(t, dir, "beads-hook", beadsPostCheckoutHook)
+	writeHook(t, dir, "normal-hook", nonBeadsHook)
+
+	assert.True(t, isBeadsHook(filepath.Join(dir, "beads-hook")))
+	assert.False(t, isBeadsHook(filepath.Join(dir, "normal-hook")))
+	assert.False(t, isBeadsHook(filepath.Join(dir, "nonexistent")))
+}

--- a/cmd/linear.go
+++ b/cmd/linear.go
@@ -42,7 +42,7 @@ Examples:
 Authentication:
   The Linear API key can be provided via (in order of precedence):
   1. --api-key flag
-  2. [linear] api_key in .co/config.toml
+  2. [linear] api_key in .sarge/config.toml
 
 Environment Variables:
   BEANS_PATH         Beans directory (default: auto-detect)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Project configuration is stored in `.co/config.toml`.
+Project configuration is stored in `.sarge/config.toml`.
 
 ## Full Example
 

--- a/internal/agents/runner/runner.go
+++ b/internal/agents/runner/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sargehq/sarge/internal/beans/pubsub"
 	"github.com/sargehq/sarge/internal/db"
+	"github.com/sargehq/sarge/internal/project"
 	trackingwatcher "github.com/sargehq/sarge/internal/tracking/watcher"
 )
 
@@ -36,7 +37,7 @@ func MonitorAgent(ctx context.Context, database *db.DB, taskID string, agentCmd 
 	var watcherSub <-chan pubsub.Event[trackingwatcher.WatcherEvent]
 	var ticker *time.Ticker
 
-	trackingDBPath := filepath.Join(projectRoot, ".co", "tracking.db")
+	trackingDBPath := filepath.Join(projectRoot, project.ConfigDir, "tracking.db")
 	watcher, err := trackingwatcher.New(trackingwatcher.DefaultConfig(trackingDBPath))
 	if err == nil {
 		if err := watcher.Start(); err == nil {

--- a/internal/beans/cli.go
+++ b/internal/beans/cli.go
@@ -247,10 +247,15 @@ func (c *cliImpl) AddDependency(ctx context.Context, beanID, dependsOnID string)
 }
 
 // Init initializes beans in the specified directory.
-func Init(ctx context.Context, beansDir, prefix string) error {
-	cmd := beansCommand(ctx, "", "init", "--prefix", prefix)
-	// beans init creates .beans/ in the current working directory
+// projectRoot is the directory containing .mise.toml so that mise can locate the
+// beans binary it just installed (which may not yet be on the global PATH).
+func Init(ctx context.Context, beansDir, projectRoot string) error {
+	if err := os.MkdirAll(beansDir, 0o750); err != nil {
+		return fmt.Errorf("beans init failed: could not create directory: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "mise", "exec", "--", "beans", "init")
 	cmd.Dir = beansDir
+	cmd.Env = append(os.Environ(), "MISE_PROJECT_DIR="+projectRoot)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("beans init failed: %w\n%s", err, output)
 	}

--- a/internal/control/loop.go
+++ b/internal/control/loop.go
@@ -50,7 +50,7 @@ func RunControlPlaneLoopWithControlPlane(ctx context.Context, proj *project.Proj
 	}
 
 	// Initialize tracking database watcher
-	trackingDBPath := filepath.Join(proj.Root, ".co", "tracking.db")
+	trackingDBPath := filepath.Join(proj.Root, project.ConfigDir, "tracking.db")
 	watcher, err := trackingwatcher.New(trackingwatcher.DefaultConfig(trackingDBPath))
 	if err != nil {
 		return fmt.Errorf("failed to create tracking watcher: %w", err)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,5 +1,5 @@
 // Package logging provides structured logging using slog.
-// Logs are written to .co/debug.log in append mode.
+// Logs are written to .sarge/debug.log in append mode.
 package logging
 
 import (
@@ -14,8 +14,6 @@ import (
 const (
 	// LogFileName is the name of the debug log file.
 	LogFileName = "debug.log"
-	// ConfigDir is the directory name for project configuration.
-	ConfigDir = ".co"
 )
 
 var (
@@ -27,10 +25,10 @@ var (
 	mu sync.RWMutex
 )
 
-// Init initializes the logger with the project root path.
-// Logs are written to <projectRoot>/.co/debug.log in append mode.
+// Init initializes the logger with the project root path and config directory name.
+// Logs are written to <projectRoot>/<configDir>/debug.log in append mode.
 // If projectRoot is empty, logging is disabled (writes to io.Discard).
-func Init(projectRoot string) error {
+func Init(projectRoot, configDir string) error {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -45,11 +43,11 @@ func Init(projectRoot string) error {
 		// No project root - disable logging.
 		w = io.Discard
 	} else {
-		logPath := filepath.Join(projectRoot, ConfigDir, LogFileName)
+		logPath := filepath.Join(projectRoot, configDir, LogFileName)
 
-		// Ensure the .co directory exists.
-		coDir := filepath.Join(projectRoot, ConfigDir)
-		if err := os.MkdirAll(coDir, 0755); err != nil {
+		// Ensure the config directory exists.
+		dir := filepath.Join(projectRoot, configDir)
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			// Fall back to discard if we can't create the directory.
 			w = io.Discard
 		} else {

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -16,7 +16,7 @@ import (
 //go:embed templates/config.tmpl
 var configTemplateText string
 
-// Config represents the project configuration stored in .co/config.toml.
+// Config represents the project configuration stored in .sarge/config.toml.
 type Config struct {
 	Project     ProjectConfig     `toml:"project"`
 	Repo        RepoConfig        `toml:"repo"`
@@ -326,7 +326,7 @@ func (m *MultiplexerConfig) GetTerminalCommand() string {
 type BeansConfig struct {
 	// Path to beans directory (relative to project root)
 	// "main/.beans" = beans in repository (synced with git)
-	// ".co/.beans" = project-local beans (standalone, not synced)
+	// ".sarge/.beans" = project-local beans (standalone, not synced)
 	Path string `toml:"path"`
 }
 
@@ -348,11 +348,19 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
-		keys := make([]string, len(undecoded))
-		for i, k := range undecoded {
-			keys[i] = k.String()
+		var nonLegacy []string
+		for _, k := range undecoded {
+			key := k.String()
+			// Skip legacy [beads] keys silently — the caller (load) will
+			// detect the empty Beans.Path and auto-configure beans.
+			if key == "beads" || strings.HasPrefix(key, "beads.") {
+				continue
+			}
+			nonLegacy = append(nonLegacy, key)
 		}
-		return nil, fmt.Errorf("unrecognized keys in config file %s: %s (possible commented-out section header with uncommented keys)", path, strings.Join(keys, ", "))
+		if len(nonLegacy) > 0 {
+			return nil, fmt.Errorf("unrecognized keys in config file %s: %s (possible commented-out section header with uncommented keys)", path, strings.Join(nonLegacy, ", "))
+		}
 	}
 
 	return &cfg, nil

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -922,6 +922,30 @@ bogus_key = "oops"
 	require.Contains(t, err.Error(), "bogus_key")
 }
 
+func TestLoadConfig_LegacyBeadsSection(t *testing.T) {
+	// A config with the retired [beads] section should be accepted
+	// with an empty Beans.Path, allowing the caller to auto-configure beans.
+	configContent := `
+[project]
+name = "test"
+
+[repo]
+type = "local"
+source = "/path/to/repo"
+path = "main"
+
+[beads]
+path = "main/.beads"
+`
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0600))
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "", cfg.Beans.Path, "Beans.Path should be empty when [beads] is present")
+}
+
 func TestGetAttachMode_DefaultsToWindow(t *testing.T) {
 	m := &MultiplexerConfig{}
 	require.Equal(t, "window", m.GetAttachMode())

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -19,7 +19,9 @@ import (
 
 const (
 	// ConfigDir is the directory name for project configuration.
-	ConfigDir = ".co"
+	ConfigDir = ".sarge"
+	// LegacyConfigDir is the old directory name, still recognized for existing projects.
+	LegacyConfigDir = ".co"
 	// ConfigFile is the name of the project config file.
 	ConfigFile = "config.toml"
 	// TrackingDB is the name of the tracking database file.
@@ -90,8 +92,8 @@ func Find(ctx context.Context, flagValue string) (*Project, error) {
 	return find(ctx, cwd)
 }
 
-// find walks up from startDir looking for a .co/ directory.
-// Returns the project if found, or an error if not found.
+// find walks up from startDir looking for a .sarge/ directory.
+// If a legacy .co/ directory is found instead, it is renamed to .sarge/ before loading.
 func find(ctx context.Context, startDir string) (*Project, error) {
 	dir, err := filepath.Abs(startDir)
 	if err != nil {
@@ -104,16 +106,50 @@ func find(ctx context.Context, startDir string) (*Project, error) {
 			return load(ctx, dir)
 		}
 
+		// Migrate legacy .co/ to .sarge/
+		legacyConfig := filepath.Join(dir, LegacyConfigDir, ConfigFile)
+		if _, err := os.Stat(legacyConfig); err == nil {
+			if err := migrateLegacyConfigDir(dir); err != nil {
+				return nil, err
+			}
+			return load(ctx, dir)
+		}
+
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// Reached filesystem root
 			return nil, fmt.Errorf("no project found (no %s directory)", ConfigDir)
 		}
 		dir = parent
 	}
 }
 
+// migrateLegacyConfigDir renames .co/ to .sarge/ and rewrites any .co/ paths
+// in the config file to .sarge/.
+func migrateLegacyConfigDir(projectRoot string) error {
+	oldDir := filepath.Join(projectRoot, LegacyConfigDir)
+	newDir := filepath.Join(projectRoot, ConfigDir)
+	if err := os.Rename(oldDir, newDir); err != nil {
+		return fmt.Errorf("failed to migrate %s to %s: %w", LegacyConfigDir, ConfigDir, err)
+	}
+	fmt.Printf("Migrated project config: %s/ -> %s/\n", LegacyConfigDir, ConfigDir)
+
+	// Rewrite .co/ references in config.toml (e.g. beans path = ".co/.beans")
+	configPath := filepath.Join(newDir, ConfigFile)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil // directory renamed successfully, config read failure is non-fatal
+	}
+	updated := strings.ReplaceAll(string(data), LegacyConfigDir+"/", ConfigDir+"/")
+	if updated != string(data) {
+		if err := os.WriteFile(configPath, []byte(updated), 0o600); err != nil {
+			fmt.Printf("Warning: could not update config paths: %v\n", err)
+		}
+	}
+	return nil
+}
+
 // load loads a project from the given root directory.
+// The config directory is always .sarge/ (legacy .co/ is migrated before load is called).
 func load(ctx context.Context, root string) (*Project, error) {
 	configPath := filepath.Join(root, ConfigDir, ConfigFile)
 	cfg, err := LoadConfig(configPath)
@@ -135,18 +171,37 @@ func load(ctx context.Context, root string) (*Project, error) {
 	proj.DB = database
 
 	// Open the beans client automatically
-	// Use the configured beans path (relative to project root)
-	beansDir := filepath.Join(root, cfg.Beans.Path)
+	beansPath := cfg.Beans.Path
+
+	// If beans path is empty (e.g., legacy [beads] config), auto-configure beans
+	// the same way a new project would — check for repo beans, otherwise init project-local.
+	if beansPath == "" {
+		mainPath := filepath.Join(root, MainDir)
+		var err error
+		beansPath, err = setupBeans(ctx, root, mainPath)
+		if err != nil {
+			database.Close()
+			return nil, fmt.Errorf("failed to auto-configure beans: %w", err)
+		}
+		cfg.Beans.Path = beansPath
+		// Persist the updated config so this migration only happens once
+		if err := commentOutBeadsAndSaveBeans(configPath, beansPath); err != nil {
+			fmt.Printf("Warning: could not update config file: %v\n", err)
+		} else {
+			fmt.Printf("Migrated config: commented out [beads], added [beans] path = %q\n", beansPath)
+		}
+	}
+
+	beansDir := filepath.Join(root, beansPath)
 	beansClient, err := beans.NewClient(ctx, beans.ClientConfig{BeansDir: beansDir})
 	if err != nil {
 		database.Close() // Clean up the already-opened DB
-		return nil, fmt.Errorf("failed to open beans client: %w", err)
+		return nil, fmt.Errorf("failed to open beans client at %s: %w", beansDir, err)
 	}
 	proj.Beans = beansClient
 
-	// Initialize logging to .co/debug.log
-	if err := logging.Init(root); err != nil {
-		// Log initialization failure is non-fatal, but log it if we can
+	// Initialize logging
+	if err := logging.Init(root, ConfigDir); err != nil {
 		logging.Warn("failed to initialize logging", "error", err)
 	}
 
@@ -169,11 +224,13 @@ func CreateWithSelections(ctx context.Context, dir, repoSource string, agentType
 		return nil, fmt.Errorf("failed to resolve path: %w", err)
 	}
 
-	// Check if project already exists
-	configDir := filepath.Join(absDir, ConfigDir)
-	if _, err := os.Stat(configDir); err == nil {
-		return nil, fmt.Errorf("project already exists at %s", absDir)
+	// Check if project already exists (check both .sarge and legacy .co)
+	for _, dir := range []string{ConfigDir, LegacyConfigDir} {
+		if _, err := os.Stat(filepath.Join(absDir, dir)); err == nil {
+			return nil, fmt.Errorf("project already exists at %s (found %s)", absDir, dir)
+		}
 	}
+	configDir := filepath.Join(absDir, ConfigDir)
 
 	// 1. Create project directory structure
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -220,7 +277,7 @@ func CreateWithSelections(ctx context.Context, dir, repoSource string, agentType
 	}
 
 	// 5. Initialize beans (after mise, so beans CLI is available)
-	beansPath, err := setupBeans(ctx, repoSource, absDir, mainPath)
+	beansPath, err := setupBeans(ctx, absDir, mainPath)
 	if err != nil {
 		os.RemoveAll(absDir)
 		return nil, err
@@ -254,7 +311,7 @@ func CreateWithSelections(ctx context.Context, dir, repoSource string, agentType
 const BeansPathRepo = "main/.beans"
 
 // BeansPathProject is the path for project-local beans (standalone, not synced).
-const BeansPathProject = ".co/.beans"
+const BeansPathProject = ".sarge/.beans"
 
 // cloneRepo sets up the main/ directory based on the repo source.
 // It only handles cloning/symlinking the repository.
@@ -292,7 +349,7 @@ func cloneRepo(ctx context.Context, source, mainPath string) (repoType string, e
 
 // setupBeans initializes or connects to beans for the project.
 // Returns the beans path (relative to project root).
-func setupBeans(ctx context.Context, source, projectRoot, mainPath string) (beansPath string, err error) {
+func setupBeans(ctx context.Context, projectRoot, mainPath string) (beansPath string, err error) {
 	// Check if repo already has beans
 	repoBeansPath := filepath.Join(mainPath, ".beans")
 	if _, err := os.Stat(repoBeansPath); err == nil {
@@ -305,11 +362,8 @@ func setupBeans(ctx context.Context, source, projectRoot, mainPath string) (bean
 		fmt.Printf("Initializing project-local beans in %s\n", projectBeansPath)
 		beansPath = BeansPathProject
 
-		// Derive prefix from repo name
-		prefix := repoNameFromSource(source)
-
 		// Initialize beans in project directory
-		if err := beans.Init(ctx, projectBeansPath, prefix); err != nil {
+		if err := beans.Init(ctx, projectBeansPath, projectRoot); err != nil {
 			return "", fmt.Errorf("failed to initialize beans: %w", err)
 		}
 	}
@@ -349,31 +403,47 @@ func isGitHubURL(source string) bool {
 		strings.HasPrefix(source, "http://github.com/")
 }
 
-// repoNameFromSource extracts the first letter of the repository name from a source URL or path.
-// For GitHub URLs: https://github.com/org/services -> "s"
-// For local paths: /path/to/myrepo -> "m"
-func repoNameFromSource(source string) string {
-	// Remove trailing slashes and .git suffix
-	source = strings.TrimSuffix(source, "/")
-	source = strings.TrimSuffix(source, ".git")
 
-	var name string
-	// For GitHub URLs, extract the repo name (last path component)
-	if isGitHubURL(source) {
-		parts := strings.Split(source, "/")
-		if len(parts) > 0 {
-			name = parts[len(parts)-1]
+// commentOutBeadsAndSaveBeans reads the config file, comments out any [beads]
+// section, and appends a [beans] section with the given path.
+func commentOutBeadsAndSaveBeans(configPath, beansPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	inBeads := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "[beads]" {
+			inBeads = true
+			out = append(out, "# "+line+" # migrated to [beans]")
+			continue
 		}
-	} else {
-		// For local paths, use the directory name
-		name = filepath.Base(source)
+		// Stop commenting when we hit the next section or end of file
+		if inBeads && strings.HasPrefix(trimmed, "[") && trimmed != "[beads]" {
+			inBeads = false
+		}
+		if inBeads {
+			out = append(out, "# "+line)
+		} else {
+			out = append(out, line)
+		}
 	}
 
-	// Return just the first letter (lowercase)
-	if len(name) > 0 {
-		return strings.ToLower(string(name[0]))
-	}
-	return "b" // fallback prefix
+	// Append the new [beans] section
+	out = append(out,
+		"",
+		"# =============================================================================",
+		"# Beans Configuration",
+		"# =============================================================================",
+		"[beans]",
+		fmt.Sprintf("path = %q", beansPath),
+	)
+
+	return os.WriteFile(configPath, []byte(strings.Join(out, "\n")), 0o600)
 }
 
 // MainRepoPath returns the path to the main repository.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -139,7 +139,7 @@ func migrateLegacyConfigDir(projectRoot string) error {
 	if err != nil {
 		return nil // directory renamed successfully, config read failure is non-fatal
 	}
-	updated := strings.ReplaceAll(string(data), LegacyConfigDir+"/", ConfigDir+"/")
+	updated := strings.ReplaceAll(string(data), "\""+LegacyConfigDir+"/", "\""+ConfigDir+"/")
 	if updated != string(data) {
 		if err := os.WriteFile(configPath, []byte(updated), 0o600); err != nil {
 			fmt.Printf("Warning: could not update config paths: %v\n", err)
@@ -357,14 +357,17 @@ func setupBeans(ctx context.Context, projectRoot, mainPath string) (beansPath st
 		fmt.Printf("Using existing beans in %s\n", repoBeansPath)
 		beansPath = BeansPathRepo
 	} else {
-		// No beans in repo - create project-local beans
 		projectBeansPath := filepath.Join(projectRoot, ConfigDir, ".beans")
-		fmt.Printf("Initializing project-local beans in %s\n", projectBeansPath)
 		beansPath = BeansPathProject
 
-		// Initialize beans in project directory
-		if err := beans.Init(ctx, projectBeansPath, projectRoot); err != nil {
-			return "", fmt.Errorf("failed to initialize beans: %w", err)
+		// Skip init if beans already exist (e.g. migrated from .co/.beans/)
+		if _, err := os.Stat(filepath.Join(projectBeansPath, ".beans.yml")); err == nil {
+			fmt.Printf("Using existing project-local beans in %s\n", projectBeansPath)
+		} else {
+			fmt.Printf("Initializing project-local beans in %s\n", projectBeansPath)
+			if err := beans.Init(ctx, projectBeansPath, projectRoot); err != nil {
+				return "", fmt.Errorf("failed to initialize beans: %w", err)
+			}
 		}
 	}
 

--- a/internal/project/templates/config.tmpl
+++ b/internal/project/templates/config.tmpl
@@ -36,7 +36,7 @@ path = {{.RepoPath | tomlString}}
 [beans]
 # Path to beans directory (relative to project root)
 # "main/.beans" = Uses beans in repository (synced with git)
-# ".co/.beans" = Project-local beans (standalone, not synced)
+# ".sarge/.beans" = Project-local beans (standalone, not synced)
 path = {{.BeansPath | tomlString}}
 
 # =============================================================================

--- a/internal/tui/tui_plan.go
+++ b/internal/tui/tui_plan.go
@@ -139,7 +139,7 @@ func newPlanModel(ctx context.Context, proj *project.Project) *planModel {
 	}
 
 	// Initialize tracking database watcher
-	trackingDBPath := filepath.Join(proj.Root, ".co", "tracking.db")
+	trackingDBPath := filepath.Join(proj.Root, project.ConfigDir, "tracking.db")
 	trackingWatcher, err := trackingwatcher.New(trackingwatcher.DefaultConfig(trackingDBPath))
 	if err != nil {
 		// Log error but continue without watcher


### PR DESCRIPTION
## Summary

- New projects use `.sarge/` instead of `.co/` for config, tracking DB, logs, and project-local beans
- Existing projects with `.co/` are auto-migrated to `.sarge/` on first load (directory rename + config path rewrite)
- Legacy configs with a `[beads]` section are auto-migrated to `[beans]` on first load

## Additional fixes

- `beans.Init` now creates the target directory before running `beans init`, fixing project creation failures
- `beans.Init` now invokes `beans` through `mise exec` so the newly installed binary is found even when it's not yet on the global PATH (incorporates the fix from #72)
- Removed unsupported `--prefix` flag from `beans init` call (not supported by beans 0.4.0)
- Cleaned up dead `repoNameFromSource` code that only served the removed prefix
- `setupBeans()` now checks for existing `.beans.yml` before calling `beans.Init`, preventing re-initialization of migrated project-local beans
- `migrateLegacyConfigDir()` scopes the `.co/` to `.sarge/` path replacement to TOML string values (matching `".co/`) to avoid false positives

## Beads-to-beans auto-migration

beads (`steveyegge/beads`) and beans (`hmans/beans`) are different upstream tools by different authors with incompatible data formats (SQLite vs markdown). The migration PRs (#63, #64) updated Go code but never migrated existing project `config.toml` files. When a legacy `[beads]` section is detected, sarge now auto-configures beans the same way a new project would (detect repo `.beans/` or init project-local), comments out the old `[beads]` section, and appends a `[beans]` section. This is a one-time migration that persists to the config file.

## Test plan

- [x] All existing tests pass (`go test ./...` — 28 packages, 0 failures)
- [x] `sarge proj create` creates `.sarge/` directory
- [x] Legacy `[beads]` config auto-migrates to `[beans]` on first load
- [x] `beans.Init` creates target directory and `beans init` succeeds without `--prefix`
- [x] Migrated project-local beans (`.sarge/.beans/` with `.beans.yml`) are not re-initialized
- [x] Config path replacement only affects TOML string values, not arbitrary text

Supersedes #72.